### PR TITLE
Only run the tests in GA on pushes to the master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Otherwise we get double runs when pushing to another branch with a PR
already open. I forgot about this scenario when setting it up before,
but I've seen it in a couple other projects.

This unfortunately means that simple pushes to a different branch won't
build, until you've opened a PR. But you can always open a draft PR to
get the build going there then, which also helps to have a place to
document and/or discuss stuff as you're working through it.

<details>
<summary>Double run sample</summary>

![Screen Shot 2021-12-15 at 18 22 18](https://user-images.githubusercontent.com/26328/146266908-4ecbaebf-9ec2-4dcf-bbdd-c5f1dac27b52.png)

</details>