### PR TITLE
Require Ruby 2.6+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
         gemfile:
           - Gemfile
         ruby:
-          - 2.5
           - 2.6
           - 2.7
           - 3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...master)
 
 - Rails Autoscale is now Judoscale.
+- Require Ruby 2.6 or newer.
 
 ## [0.10.2](https://github.com/adamlogic/rails_autoscale_agent/compare/v0.10.1...v0.10.2) - 2021-01-12
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This gem works together with the [Judoscale](https://judoscale.com) Heroku add-o
 ## Requirements
 
 - Rack-based app
-- Ruby 2.5 or newer
+- Ruby 2.6 or newer
 
 ## Getting Started
 

--- a/judoscale.gemspec
+++ b/judoscale.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.metadata = {
     "homepage_uri" => "https://judoscale.com",


### PR DESCRIPTION
2.5 is not supported by Ruby core anymore, 2.6 is in security
maintenance until March 2022.

More info: https://www.ruby-lang.org/en/downloads/branches/