### PR TITLE
Refactor log specs to not rely on a temp file

### DIFF
--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -4,30 +4,28 @@ require "spec_helper"
 require "judoscale/logger"
 
 module Judoscale
-  LOGFILE = "tmp/logger_spec_output.log"
-
   describe Logger do
     include Logger
 
     def messages
-      File.read(LOGFILE).chomp.lines
+      string_io.string
     end
 
-    let(:original_logger) { ::Logger.new(LOGFILE) }
+    let(:string_io) { StringIO.new }
+    let(:original_logger) { ::Logger.new(string_io) }
 
-    before { `mkdir -p tmp && rm -f #{LOGFILE}` }
     before { Config.instance.logger = original_logger }
 
     describe "#info" do
       it "delegates to the original logger, prepending Judoscale" do
         logger.info "some info"
-        expect(messages.last).to include "INFO -- : [Judoscale] some info"
+        expect(messages).to include "INFO -- : [Judoscale] some info"
       end
 
       it "can be silenced via config" do
         use_config quiet: true do
           logger.info "some info"
-          expect(messages.last).to_not include "INFO -- : [Judoscale] some info"
+          expect(messages).to_not include "INFO -- : [Judoscale] some info"
         end
       end
     end
@@ -35,7 +33,7 @@ module Judoscale
     describe "#debug" do
       it "silences debug logs by default" do
         logger.debug "silence"
-        expect(messages.last).to_not include "silence"
+        expect(messages).to_not include "silence"
       end
 
       context "configured to allow debug logs" do
@@ -44,13 +42,13 @@ module Judoscale
         it "includes debug logs if the mail logger.level is DEBUG" do
           original_logger.level = "DEBUG"
           logger.debug "some noise"
-          expect(messages.last).to include "DEBUG -- : [Judoscale] some noise"
+          expect(messages).to include "DEBUG -- : [Judoscale] some noise"
         end
 
         it "includes debug logs if the mail logger.level is INFO" do
           original_logger.level = "INFO"
           logger.debug "some noise"
-          expect(messages.last).to include "INFO -- : [Judoscale] [DEBUG] some noise"
+          expect(messages).to include "INFO -- : [Judoscale] [DEBUG] some noise"
         end
       end
     end


### PR DESCRIPTION
Use a StringIO to receive log output simulating a file, and read the log
string out of it to test against. This way we can leave the logging all
in memory, avoiding having to manage / cleanup the temp log file.