### PR TITLE
Quote Ruby versions in GH workflow declaration to avoid YAML float conversion issue with 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
         gemfile:
           - Gemfile
         ruby:
-          - 2.6
-          - 2.7
-          - 3.0
+          - '2.6'
+          - '2.7'
+          - '3.0'
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
@@ -32,7 +32,7 @@ jobs:
         gemfile:
           - Gemfile
         ruby:
-          - 3.0
+          - '3.0'
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -15,7 +15,7 @@ module Judoscale
 
   describe Middleware do
     describe "#call" do
-      before { Reporter.instance.instance_variable_set("@running", nil) }
+      before { Reporter.instance.instance_variable_set(:@running, nil) }
 
       let(:app) { MockApp.new }
       let(:env) {

--- a/spec/reporter_spec.rb
+++ b/spec/reporter_spec.rb
@@ -18,7 +18,7 @@ module Judoscale
     describe "#report!" do
       it "reports stored metrics to the API" do
         store = Store.instance
-        store.instance_variable_set "@measurements", []
+        store.instance_variable_set :@measurements, []
 
         expected_query = {dyno: "web.0", pid: Process.pid}
         expected_body = "1000000001,11,,\n1000000002,22,high,\n"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,5 +46,5 @@ ActiveRecord::Schema.define do
 end
 
 RSpec.configure do |c|
-  c.before(:example) { Singleton.__init__(Judoscale::Config) if Object.const_defined?("Judoscale::Config") }
+  c.before(:example) { Singleton.__init__(Judoscale::Config) }
 end

--- a/spec/worker_adapters/delayed_job_spec.rb
+++ b/spec/worker_adapters/delayed_job_spec.rb
@@ -20,7 +20,7 @@ module Judoscale
     describe "#collect!" do
       before { subject.queues = nil }
       before { ActiveRecord::Base.connection.execute("DELETE FROM delayed_jobs") }
-      after { Store.instance.instance_variable_set "@measurements", [] }
+      after { Store.instance.instance_variable_set :@measurements, [] }
 
       it "collects latency for each queue" do
         store = Store.instance

--- a/spec/worker_adapters/que_spec.rb
+++ b/spec/worker_adapters/que_spec.rb
@@ -23,7 +23,7 @@ module Judoscale
     describe "#collect!" do
       before { subject.queues = nil }
       before { ActiveRecord::Base.connection.execute("DELETE FROM que_jobs") }
-      after { Store.instance.instance_variable_set "@measurements", [] }
+      after { Store.instance.instance_variable_set :@measurements, [] }
 
       it "collects latency for each queue" do
         store = Store.instance

--- a/spec/worker_adapters/resque_spec.rb
+++ b/spec/worker_adapters/resque_spec.rb
@@ -14,7 +14,7 @@ module Judoscale
 
     describe "#collect!" do
       before { subject.queues = nil }
-      after { Store.instance.instance_variable_set "@measurements", [] }
+      after { Store.instance.instance_variable_set :@measurements, [] }
 
       it "collects latency for each queue" do
         expect(subject.enabled?).to be_truthy
@@ -58,7 +58,7 @@ module Judoscale
         allow(::Resque).to receive(:size) { 0 }
         subject.collect! store
 
-        Store.instance.instance_variable_set "@measurements", []
+        Store.instance.instance_variable_set :@measurements, []
         allow(::Resque).to receive(:queues) { [] }
         subject.collect! store
 

--- a/spec/worker_adapters/sidekiq_spec.rb
+++ b/spec/worker_adapters/sidekiq_spec.rb
@@ -14,7 +14,7 @@ module Judoscale
 
     describe "#collect!" do
       before { subject.queues = nil }
-      after { Store.instance.instance_variable_set "@measurements", [] }
+      after { Store.instance.instance_variable_set :@measurements, [] }
 
       it "collects latency for each queue" do
         expect(subject.enabled?).to be_truthy
@@ -72,7 +72,7 @@ module Judoscale
         allow_any_instance_of(::Sidekiq::Queue).to receive(:latency) { 0 }
         subject.collect! store
 
-        Store.instance.instance_variable_set "@measurements", []
+        Store.instance.instance_variable_set :@measurements, []
         allow(::Sidekiq::Queue).to receive(:all) { [] }
         subject.collect! store
 


### PR DESCRIPTION
Quote Ruby versions to avoid YAML float conversion issue with 3.0

Due to an issue with how `3.0` is parsed as float 3 in YAML [1], the
workflow actually started building with 3.1 once it was released a
couple weeks ago during Christmas.

The current workaround seems to be quote it to avoid the float
conversion, so for consistency I quoted all of the versions.

I'm going to look into including 3.1 in the build matrix, but as a
separate commit since it seems to require code changes.

[1] https://github.com/actions/runner/issues/849

---

Note: I'm not adding Ruby 3.1 to the matrix yet because I ran into this issue with standardrb / rubocop:
https://github.com/testdouble/standard/issues/375

```
standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
standard: Run `standardrb --fix` to automatically fix some problems.
  lib/judoscale/autoscale_api.rb:35:22: Style/HashSyntax: Omit the hash value.
  lib/judoscale/autoscale_api.rb:35:60: Style/HashSyntax: Omit the hash value.
  lib/judoscale/autoscale_api.rb:40:22: Style/HashSyntax: Omit the hash value.
  lib/judoscale/autoscale_api.rb:40:49: Style/HashSyntax: Omit the hash value.
```

We can't make that change since it's 3.1 only, so I think we can just wait a bit for standardrb there.