### PR TITLE
Cleanup registration request/config

### DIFF
--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -25,7 +25,7 @@ module Judoscale
       @track_long_running_jobs = ENV["JUDOSCALE_LONG_JOBS"] == "true"
       @max_queues = ENV.fetch("JUDOSCALE_MAX_QUEUES", 50).to_i
       @max_request_size = 100_000 # ignore request payloads over 100k since they skew the queue times
-      @report_interval = 10 # this default will be overwritten during Reporter#register!
+      @report_interval = 10
       @logger ||= defined?(Rails) ? Rails.logger : ::Logger.new($stdout)
       @dyno = dev_mode? ? "dev.1" : ENV["DYNO"]
     end

--- a/lib/judoscale/registration.rb
+++ b/lib/judoscale/registration.rb
@@ -3,10 +3,9 @@
 require "judoscale/version"
 
 module Judoscale
-  class Registration < Struct.new(:config, :worker_adapters)
+  class Registration < Struct.new(:worker_adapters)
     def to_params
       {
-        dyno: config.dyno,
         pid: Process.pid,
         ruby_version: RUBY_VERSION,
         rails_version: defined?(Rails) && Rails.version,

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -74,7 +74,7 @@ module Judoscale
     end
 
     def register!(config, worker_adapters)
-      params = Registration.new(config, worker_adapters).to_params
+      params = Registration.new(worker_adapters).to_params
       result = AutoscaleApi.new(config).register_reporter!(params)
 
       case result

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -80,8 +80,6 @@ module Judoscale
       case result
       when AutoscaleApi::SuccessResponse
         @registered = true
-        config.report_interval = result.data["report_interval"] if result.data["report_interval"]
-        config.max_request_size = result.data["max_request_size"] if result.data["max_request_size"]
         worker_adapters_msg = worker_adapters.map { |a| a.class.name }.join(", ")
         logger.info "Reporter starting, will report every #{config.report_interval} seconds or so. Worker adapters: [#{worker_adapters_msg}]"
       when AutoscaleApi::FailureResponse

--- a/test/autoscale_api_test.rb
+++ b/test/autoscale_api_test.rb
@@ -56,7 +56,6 @@ describe Judoscale::AutoscaleApi, vcr: {record: :once} do
     it "returns a successful response" do
       config.api_base_url = "http://judoscale.dev/api/test-app-token"
       registration_params = {
-        dyno: "web.1",
         pid: "1232"
       }
       autoscale_api = Judoscale::AutoscaleApi.new(config)

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -57,7 +57,7 @@ module Judoscale
             worker_adapters: ""
           }
         }
-        response = {report_interval: 123}.to_json
+        response = {}.to_json
         stub = stub_request(:post, "http://example.com/api/test-token/registrations")
           .with(body: expected_body)
           .to_return(body: response)

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -50,7 +50,6 @@ module Judoscale
       it "registers the reporter with contextual info" do
         expected_body = {
           registration: {
-            dyno: "web.0",
             pid: Process.pid,
             ruby_version: RUBY_VERSION,
             rails_version: "5.0.fake",

--- a/test/vcr_cassettes/Judoscale_AutoscaleApi/_register_reporter_/returns_a_successful_response.yml
+++ b/test/vcr_cassettes/Judoscale_AutoscaleApi/_register_reporter_/returns_a_successful_response.yml
@@ -46,7 +46,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"report_interval":15}'
+      string: '{}'
     http_version:
   recorded_at: Sun, 02 Jul 2017 16:34:30 GMT
 recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/Judoscale_AutoscaleApi/_register_reporter_/returns_a_successful_response.yml
+++ b/test/vcr_cassettes/Judoscale_AutoscaleApi/_register_reporter_/returns_a_successful_response.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://judoscale.dev/api/test-app-token/registrations
     body:
       encoding: UTF-8
-      string: '{"registration":{"dyno":"web.1","pid":"1232"}}'
+      string: '{"registration":{"pid":"1232"}}'
     headers:
       Content-Type:
       - application/json


### PR DESCRIPTION
- Remove "dyno" from registration params, and drop the "config" object passed around.
- Remove not used runtime config updates based on registration response.