### PR TITLE
Allow logging multiple messages in separate lines, all tagged

### DIFF
--- a/lib/judoscale/logger.rb
+++ b/lib/judoscale/logger.rb
@@ -13,35 +13,35 @@ module Judoscale
   class LoggerProxy < Struct.new(:logger)
     TAG = "[Judoscale]"
 
-    def error(msg)
-      logger.error tag(msg)
+    def error(*msgs)
+      logger.error tag(msgs)
     end
 
-    def warn(msg)
-      logger.warn tag(msg)
+    def warn(*msgs)
+      logger.warn tag(msgs)
     end
 
-    def info(msg)
-      logger.info tag(msg) unless Config.instance.quiet?
+    def info(*msgs)
+      logger.info tag(msgs) unless Config.instance.quiet?
     end
 
-    def debug(msg)
+    def debug(*msgs)
       # Silence debug logs by default to avoiding being overly chatty (Rails logger defaults
       # to DEBUG level in production). Setting JUDOSCALE_DEBUG=true enables debug logs,
       # even if the underlying logger severity level is INFO.
       if Config.instance.debug?
         if logger.respond_to?(:debug?) && logger.debug?
-          logger.debug tag(msg)
+          logger.debug tag(msgs)
         elsif logger.respond_to?(:info?) && logger.info?
-          logger.info tag("[DEBUG] #{msg}")
+          logger.info tag(msgs.map { |msg| "[DEBUG] #{msg}" })
         end
       end
     end
 
     private
 
-    def tag(msg)
-      "#{TAG} #{msg}"
+    def tag(msgs)
+      msgs.map { |msg| "#{TAG} #{msg}" }.join("\n")
     end
   end
 end

--- a/lib/judoscale/logger.rb
+++ b/lib/judoscale/logger.rb
@@ -12,6 +12,7 @@ module Judoscale
 
   class LoggerProxy < Struct.new(:logger)
     TAG = "[Judoscale]"
+    DEBUG_TAG = "[DEBUG]"
 
     def error(*msgs)
       logger.error tag(msgs)
@@ -33,7 +34,7 @@ module Judoscale
         if logger.respond_to?(:debug?) && logger.debug?
           logger.debug tag(msgs)
         elsif logger.respond_to?(:info?) && logger.info?
-          logger.info tag(msgs.map { |msg| "[DEBUG] #{msg}" })
+          logger.info tag(msgs.map { |msg| "#{DEBUG_TAG} #{msg}" })
         end
       end
     end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -15,6 +15,20 @@ module Judoscale
       Config.instance.logger = original_logger
     end
 
+    describe "#error" do
+      it "delegates to the original logger, prepending Judoscale" do
+        logger.error "some error"
+        _(messages).must_include "ERROR -- : [Judoscale] some error"
+      end
+    end
+
+    describe "#warn" do
+      it "delegates to the original logger, prepending Judoscale" do
+        logger.warn "some warn"
+        _(messages).must_include "WARN -- : [Judoscale] some warn"
+      end
+    end
+
     describe "#info" do
       it "delegates to the original logger, prepending Judoscale" do
         logger.info "some info"

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -20,6 +20,11 @@ module Judoscale
         logger.error "some error"
         _(messages).must_include "ERROR -- : [Judoscale] some error"
       end
+
+      it "allows logging multiple error messages in separate lines, all prepending Judoscale" do
+        logger.error "some error", "error context", "more error context"
+        _(messages).must_include "ERROR -- : [Judoscale] some error\n[Judoscale] error context\n[Judoscale] more error context"
+      end
     end
 
     describe "#warn" do
@@ -27,12 +32,22 @@ module Judoscale
         logger.warn "some warn"
         _(messages).must_include "WARN -- : [Judoscale] some warn"
       end
+
+      it "allows logging multiple warn messages in separate lines, all prepending Judoscale" do
+        logger.warn "some warn", "warn context", "more warn context"
+        _(messages).must_include "WARN -- : [Judoscale] some warn\n[Judoscale] warn context\n[Judoscale] more warn context"
+      end
     end
 
     describe "#info" do
       it "delegates to the original logger, prepending Judoscale" do
         logger.info "some info"
         _(messages).must_include "INFO -- : [Judoscale] some info"
+      end
+
+      it "allows logging multiple info messages in separate lines, all prepending Judoscale" do
+        logger.info "some info", "info context", "more info context"
+        _(messages).must_include "INFO -- : [Judoscale] some info\n[Judoscale] info context\n[Judoscale] more info context"
       end
 
       it "can be silenced via config" do
@@ -62,10 +77,22 @@ module Judoscale
           _(messages).must_include "DEBUG -- : [Judoscale] some noise"
         end
 
+        it "allows logging multiple debug messages in separate lines, all prepending Judoscale" do
+          original_logger.level = "DEBUG"
+          logger.debug "some noise", "more noise"
+          _(messages).must_include "DEBUG -- : [Judoscale] some noise\n[Judoscale] more noise"
+        end
+
         it "includes debug logs if enabled and the main logger.level is INFO" do
           original_logger.level = "INFO"
           logger.debug "some noise"
           _(messages).must_include "INFO -- : [Judoscale] [DEBUG] some noise"
+        end
+
+        it "allows logging multiple debug messages in separate lines if debug mode is enabled and logger.level is INFO" do
+          original_logger.level = "INFO"
+          logger.debug "some noise", "more noise"
+          _(messages).must_include "INFO -- : [Judoscale] [DEBUG] some noise\n[Judoscale] [DEBUG] more noise"
         end
       end
     end


### PR DESCRIPTION
Instead of logging multiple lines separately to tag them individually
and facilitate searching for all logs related to Judoscale, we're going
to group the logging of related messages together (e.g. exception
messages & backtraces), so they're sent to the underlying logger as a
single log call, which should ensure they're logged as a single "unit"
and are output together with the same timestamp in the logs.

These individual lines are going to be tagged so they are easy to search
for if needed.

Reference: https://github.com/judoscale/judoscale-ruby/pull/13/files/5a460def09fe946e3cb22d77f1652a9ce30ce6e7#r787717381