### PR TITLE
Refactor instance vars usage in reporter

### DIFF
--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -26,7 +26,7 @@ module Judoscale
 
       @_thread = Thread.new do
         loop do
-          register!(config, worker_adapters) unless @registered
+          register!(config, worker_adapters) unless registered?
 
           # Stagger reporting to spread out reports from many processes
           multiplier = 1 - (rand / 4) # between 0.75 and 1.0
@@ -42,6 +42,10 @@ module Judoscale
           report_exceptions(config) { report!(config, store) }
         end
       end
+    end
+
+    def registered?
+      @registered
     end
 
     def started?


### PR DESCRIPTION
As I was looking through this code to find ways to test it further, I came across these instance vars that I think can be moved to local vars to simplify, since we don't need that state around.

On the other hand, direct instance var access for the registered check could be wrapped into a method for clearer intent & consistency with started.