### PR TITLE
Drop dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Drop dev mode. ([#16](https://github.com/judoscale/judoscale-ruby/pull/16))
 - Rails Autoscale is now Judoscale.
 - Require Ruby 2.6 or newer.
 

--- a/lib/judoscale/autoscale_api.rb
+++ b/lib/judoscale/autoscale_api.rb
@@ -40,11 +40,6 @@ module Judoscale
       uri = URI.parse("#{@config.api_base_url}#{options.fetch(:path)}")
       ssl = uri.scheme == "https"
 
-      if @config.dev_mode
-        logger.debug "[DEV_MODE] Skipping request to #{uri}"
-        return SuccessResponse.new("{}")
-      end
-
       response = Net::HTTP.start(uri.host, uri.port, use_ssl: ssl) do |http|
         request = Net::HTTP::Post.new(uri.request_uri, options[:headers] || {})
         request.body = options.fetch(:body)

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -9,7 +9,7 @@ module Judoscale
     include Singleton
 
     attr_accessor :report_interval, :logger, :api_base_url, :max_request_size,
-      :dyno, :addon_name, :worker_adapters, :dev_mode, :debug, :quiet,
+      :dyno, :addon_name, :worker_adapters, :debug, :quiet,
       :track_long_running_jobs, :max_queues,
       # legacy configs, no longer used
       :sidekiq_latency_for_active_jobs, :latency_for_active_jobs
@@ -20,14 +20,13 @@ module Judoscale
       # Allow the add-on name to be configured - needed for testing
       @addon_name = ENV["JUDOSCALE_ADDON"] || "JUDOSCALE"
       @api_base_url = ENV["#{@addon_name}_URL"]
-      @dev_mode = ENV["JUDOSCALE_DEV"] == "true"
-      @debug = dev_mode? || ENV["JUDOSCALE_DEBUG"] == "true"
+      @debug = ENV["JUDOSCALE_DEBUG"] == "true"
       @track_long_running_jobs = ENV["JUDOSCALE_LONG_JOBS"] == "true"
       @max_queues = ENV.fetch("JUDOSCALE_MAX_QUEUES", 50).to_i
       @max_request_size = 100_000 # ignore request payloads over 100k since they skew the queue times
       @report_interval = 10
       @logger ||= defined?(Rails) ? Rails.logger : ::Logger.new($stdout)
-      @dyno = dev_mode? ? "dev.1" : ENV["DYNO"]
+      @dyno = ENV["DYNO"]
     end
 
     def to_s
@@ -38,7 +37,6 @@ module Judoscale
       @max_request_size
     end
 
-    alias_method :dev_mode?, :dev_mode
     alias_method :debug?, :debug
     alias_method :quiet?, :quiet
 

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -19,7 +19,7 @@ module Judoscale
       worker_adapters = config.worker_adapters.select(&:enabled?)
       dyno_num = config.dyno.to_s.split(".").last.to_i
 
-      if !config.api_base_url && !config.dev_mode?
+      if !config.api_base_url
         logger.info "Reporter not started: #{config.addon_name}_URL is not set"
         return
       end

--- a/lib/judoscale/request.rb
+++ b/lib/judoscale/request.rb
@@ -25,9 +25,6 @@ module Judoscale
         # and it might be preceeded by "t=". We can all cases by removing non-digits
         # and treating as milliseconds.
         Time.at(@request_start_header.gsub(/\D/, "").to_i / 1000.0)
-      elsif @config.dev_mode?
-        # In dev mode, fake a queue time of 0-1000ms
-        Time.now - rand + @request_body_wait
       end
     end
 

--- a/test/autoscale_api_test.rb
+++ b/test/autoscale_api_test.rb
@@ -5,7 +5,7 @@ require "judoscale/autoscale_api"
 
 describe Judoscale::AutoscaleApi, vcr: {record: :once} do
   let(:measurements_csv) { "#{Time.now.to_i},11\n#{Time.now.to_i},33\n" }
-  let(:config) { Struct.new(:api_base_url, :dev_mode).new("http://example.com", false) }
+  let(:config) { Struct.new(:api_base_url).new("http://example.com") }
 
   describe "#report_metrics!" do
     it "returns a successful response" do


### PR DESCRIPTION
This simplifies some branches that were trying to replicate real
behavior to facilitate local development of the library.