### PR TITLE
Prefix queue time added to the rack env with `judoscale`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Change the `queue_time` rack env value exposed to the app to `judoscale.queue_time`. ([#18](https://github.com/judoscale/judoscale-ruby/pull/18))
 - Drop dev mode. ([#16](https://github.com/judoscale/judoscale-ruby/pull/16))
 - Remove error reporting via the API, log exceptions with full backtraces. (that are more easily searchable now.) ([#13](https://github.com/judoscale/judoscale-ruby/pull/13))
 - Move test suite to minitest/spec. ([#8](https://github.com/judoscale/judoscale-ruby/pull/8))

--- a/lib/judoscale/middleware.rb
+++ b/lib/judoscale/middleware.rb
@@ -22,7 +22,7 @@ module Judoscale
 
       if queue_time
         # NOTE: Expose queue time to the app
-        env["queue_time"] = queue_time
+        env["judoscale.queue_time"] = queue_time
         store.push queue_time
       end
 

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -61,8 +61,8 @@ module Judoscale
           it "records the queue time in the environment passed on" do
             middleware.call(env)
 
-            _(app.env).must_include("queue_time")
-            _(app.env["queue_time"]).must_be_within_delta 5000, 1
+            _(app.env).must_include("judoscale.queue_time")
+            _(app.env["judoscale.queue_time"]).must_be_within_delta 5000, 1
           end
 
           describe "when the request body is large enough to skew the queue time" do


### PR DESCRIPTION
This helps make it clear for users of the code in their apps where the
value is coming from, who's exposing it to the app.

Note that this is a breaking change for anyone consuming it.