### PR TITLE
Require metric identifier with all measurements, including web queue time

### DIFF
--- a/lib/judoscale/measurement.rb
+++ b/lib/judoscale/measurement.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Judoscale
-  class Measurement < Struct.new(:time, :value, :queue_name, :metric)
+  class Measurement < Struct.new(:metric, :time, :value, :queue_name)
     # No queue_name is assumed to be a web request measurement
     # Metrics: qt = queue time (default), qd = queue depth (needed for Resque support)
-    def initialize(time, value, queue_name = nil, metric = nil)
-      super time.utc, value.to_i, queue_name, metric
+    def initialize(metric, time, value, queue_name = nil)
+      super metric, time.utc, value.to_i, queue_name
     end
   end
 end

--- a/lib/judoscale/middleware.rb
+++ b/lib/judoscale/middleware.rb
@@ -23,7 +23,7 @@ module Judoscale
       if queue_time
         # NOTE: Expose queue time to the app
         env["judoscale.queue_time"] = queue_time
-        store.push queue_time, Time.now, nil, :qt
+        store.push :qt, queue_time
       end
 
       @app.call(env)

--- a/lib/judoscale/middleware.rb
+++ b/lib/judoscale/middleware.rb
@@ -23,7 +23,7 @@ module Judoscale
       if queue_time
         # NOTE: Expose queue time to the app
         env["judoscale.queue_time"] = queue_time
-        store.push queue_time
+        store.push queue_time, Time.now, nil, :qt
       end
 
       @app.call(env)

--- a/lib/judoscale/store.rb
+++ b/lib/judoscale/store.rb
@@ -15,12 +15,12 @@ module Judoscale
       @last_pop = Time.now
     end
 
-    def push(value, time = Time.now, queue_name = nil, metric = nil)
+    def push(metric, value, time = Time.now, queue_name = nil)
       # If it's been two minutes since clearing out the store, stop collecting measurements.
       # There could be an issue with the reporter, and continuing to collect will consume linear memory.
       return if @last_pop && @last_pop < Time.now - 120
 
-      @measurements << Measurement.new(time, value, queue_name, metric)
+      @measurements << Measurement.new(metric, time, value, queue_name)
     end
 
     def pop_report

--- a/lib/judoscale/worker_adapters/delayed_job.rb
+++ b/lib/judoscale/worker_adapters/delayed_job.rb
@@ -61,12 +61,12 @@ module Judoscale
           latency_ms = run_at ? ((t - run_at) * 1000).ceil : 0
           latency_ms = 0 if latency_ms < 0
 
-          store.push latency_ms, t, queue
+          store.push :qt, latency_ms, t, queue
           log_msg << "dj-qt.#{queue}=#{latency_ms} "
 
           if track_long_running_jobs?
             busy_count = busy_count_by_queue[queue] || 0
-            store.push busy_count, Time.now, queue, :busy
+            store.push :busy, busy_count, Time.now, queue
             log_msg << "dj-busy.#{queue}=#{busy_count} "
           end
         end

--- a/lib/judoscale/worker_adapters/que.rb
+++ b/lib/judoscale/worker_adapters/que.rb
@@ -53,7 +53,7 @@ module Judoscale
           latency_ms = run_at ? ((t - run_at) * 1000).ceil : 0
           latency_ms = 0 if latency_ms < 0
 
-          store.push latency_ms, t, queue
+          store.push :qt, latency_ms, t, queue
           log_msg << "que.#{queue}=#{latency_ms} "
         end
 

--- a/lib/judoscale/worker_adapters/resque.rb
+++ b/lib/judoscale/worker_adapters/resque.rb
@@ -39,7 +39,7 @@ module Judoscale
         queues.each do |queue|
           next if queue.nil? || queue.empty?
           depth = ::Resque.size(queue)
-          store.push depth, Time.now, queue, :qd
+          store.push :qd, depth, Time.now, queue
           log_msg << "resque-qd.#{queue}=#{depth} "
         end
 

--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -52,8 +52,8 @@ module Judoscale
           latency_ms = (queue.latency * 1000).ceil
           depth = queue.size
 
-          store.push latency_ms, Time.now, queue_name, :qt
-          store.push depth, Time.now, queue_name, :qd
+          store.push :qt, latency_ms, Time.now, queue_name
+          store.push :qd, depth, Time.now, queue_name
           log_msg << "sidekiq-qt.#{queue_name}=#{latency_ms} sidekiq-qd.#{queue_name}=#{depth} "
 
           if track_long_running_jobs?

--- a/test/measurement_test.rb
+++ b/test/measurement_test.rb
@@ -8,14 +8,14 @@ module Judoscale
   describe Measurement do
     describe "#value" do
       it "is always an Integer" do
-        measurement = Measurement.new(Time.now, 123.45)
+        measurement = Measurement.new(:qt, Time.now, 123.45)
         _(measurement.value).must_equal 123
       end
     end
 
     describe "#time" do
       it "is always in UTC" do
-        measurement = Measurement.new(Time.iso8601("2016-12-03T01:11:00-05:00"), 123)
+        measurement = Measurement.new(:qt, Time.iso8601("2016-12-03T01:11:00-05:00"), 123)
         _(measurement.time.iso8601).must_equal "2016-12-03T06:11:00Z"
       end
     end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -56,6 +56,7 @@ module Judoscale
             _(report.measurements.length).must_equal 1
             _(report.measurements.first).must_be_instance_of Measurement
             _(report.measurements.first.value).must_be_within_delta 5000, 1
+            _(report.measurements.first.metric).must_equal :qt
           end
 
           it "records the queue time in the environment passed on" do

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -69,12 +69,12 @@ module Judoscale
         store = Store.instance
 
         expected_query = {dyno: "web.1", pid: Process.pid}
-        expected_body = "1000000001,11,,\n1000000002,22,high,\n"
+        expected_body = "1000000001,11,,qt\n1000000002,22,high,qt\n"
         stub = stub_request(:post, "http://example.com/api/test-token/v2/reports")
           .with(query: expected_query, body: expected_body)
 
-        store.push 11, Time.at(1_000_000_001) # web measurement
-        store.push 22, Time.at(1_000_000_002), "high" # worker measurement
+        store.push :qt, 11, Time.at(1_000_000_001) # web measurement
+        store.push :qt, 22, Time.at(1_000_000_002), "high" # worker measurement
 
         Reporter.instance.send :report!, Config.instance, store
 
@@ -86,7 +86,7 @@ module Judoscale
         stub_request(:post, %r{http://example.com/api/test-token/v2/reports})
           .to_return(body: "oops", status: 503)
 
-        store.push 1, Time.at(1_000_000_001) # need some measurement to trigger reporting
+        store.push :qt, 1, Time.at(1_000_000_001) # need some measurement to trigger reporting
 
         log_io = StringIO.new
         stub_logger = ::Logger.new(log_io)

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -26,6 +26,15 @@ module Judoscale
 
         _(request.queue_time(ended_at)).must_be_within_delta 1000, 1
       end
+
+      it "subtracts the network time / request body wait available in puma from the queue time" do
+        started_at = Time.now - 2
+        ended_at = started_at + 1
+        env["HTTP_X_REQUEST_START"] = (started_at.to_f * 1000).to_i.to_s
+        env["puma.request_body_wait"] = 50
+
+        _(request.queue_time(ended_at)).must_be_within_delta 950, 1
+      end
     end
   end
 end


### PR DESCRIPTION
Ensure all values pushed to the store for reporting include a metric identifier. Previously only the worker adapters were including a metric identifier together with the queue name, but not all of them, and the web measurements didn't include it, it was assumed to be queue time due to the absence of a worker queue name in the measurement/report. Now the measurements always require the metric first, to make sure there's always one attached to the value.