### PR TITLE
Collect network time as a new measurement with the web requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Collect a new metric: network time, and expose it to the app via rack env with `judoscale.network_time`. This is currently only available with Puma, and represents the time Puma spent waiting for the request body. ([#20](https://github.com/judoscale/judoscale-ruby/pull/20))
 - Change the `queue_time` rack env value exposed to the app to `judoscale.queue_time`. ([#18](https://github.com/judoscale/judoscale-ruby/pull/18))
 - Drop dev mode. ([#16](https://github.com/judoscale/judoscale-ruby/pull/16))
 - Remove error reporting via the API, log exceptions with full backtraces. (that are more easily searchable now.) ([#13](https://github.com/judoscale/judoscale-ruby/pull/13))

--- a/lib/judoscale/middleware.rb
+++ b/lib/judoscale/middleware.rb
@@ -15,7 +15,10 @@ module Judoscale
       config = Config.instance
       request = Request.new(env, config)
 
-      queue_time = request.queue_time unless request.ignore?
+      unless request.ignore?
+        queue_time = request.queue_time
+        network_time = request.network_time
+      end
 
       store = Store.instance
       Reporter.start(config, store)
@@ -24,6 +27,11 @@ module Judoscale
         # NOTE: Expose queue time to the app
         env["judoscale.queue_time"] = queue_time
         store.push :qt, queue_time
+
+        unless network_time.zero?
+          env["judoscale.network_time"] = network_time
+          store.push :nt, network_time
+        end
       end
 
       @app.call(env)

--- a/lib/judoscale/request.rb
+++ b/lib/judoscale/request.rb
@@ -42,5 +42,9 @@ module Judoscale
       # Safeguard against negative queue times (should not happen in practice)
       queue_time > 0 ? queue_time : 0
     end
+
+    def network_time
+      @request_body_wait
+    end
   end
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -76,6 +76,27 @@ module Judoscale
               _(report.measurements.length).must_equal 0
             end
           end
+
+          describe "when Puma request body wait / network time is available" do
+            before { env["puma.request_body_wait"] = 50 }
+
+            it "collects the request network time as a separate measurement" do
+              middleware.call(env)
+
+              report = Store.instance.pop_report
+              _(report.measurements.length).must_equal 2
+              _(report.measurements.last).must_be_instance_of Measurement
+              _(report.measurements.last.value).must_be_within_delta 50, 1
+              _(report.measurements.last.metric).must_equal :nt
+            end
+
+            it "records the network time in the environment passed on" do
+              middleware.call(env)
+
+              _(app.env).must_include("judoscale.network_time")
+              _(app.env["judoscale.network_time"]).must_be_within_delta 50, 1
+            end
+          end
         end
       end
 


### PR DESCRIPTION
The time that Puma spends waiting for the request body is subtracted
from the queue time for autoscaling purposes, but it's an important
metric for awareness, as it indicates large response times due to large
request payloads and/or slow clients, and Judoscale wants to expose that
to users to increase visibility on that.