### PR TITLE
Logging improvements

### DIFF
--- a/lib/judoscale/middleware.rb
+++ b/lib/judoscale/middleware.rb
@@ -3,10 +3,13 @@
 require "judoscale/store"
 require "judoscale/reporter"
 require "judoscale/config"
+require "judoscale/logger"
 require "judoscale/request"
 
 module Judoscale
   class Middleware
+    include Logger
+
     def initialize(app)
       @app = app
     end
@@ -32,6 +35,8 @@ module Judoscale
           env["judoscale.network_time"] = network_time
           store.push :nt, network_time
         end
+
+        logger.debug "Request queue_time=#{queue_time}ms network_time=#{network_time}ms request_id=#{request.id} size=#{request.size}"
       end
 
       @app.call(env)

--- a/lib/judoscale/worker_adapters/delayed_job.rb
+++ b/lib/judoscale/worker_adapters/delayed_job.rb
@@ -62,7 +62,7 @@ module Judoscale
           latency_ms = 0 if latency_ms < 0
 
           store.push :qt, latency_ms, t, queue
-          log_msg << "dj-qt.#{queue}=#{latency_ms} "
+          log_msg << "dj-qt.#{queue}=#{latency_ms}ms "
 
           if track_long_running_jobs?
             busy_count = busy_count_by_queue[queue] || 0

--- a/lib/judoscale/worker_adapters/que.rb
+++ b/lib/judoscale/worker_adapters/que.rb
@@ -54,7 +54,7 @@ module Judoscale
           latency_ms = 0 if latency_ms < 0
 
           store.push :qt, latency_ms, t, queue
-          log_msg << "que-qt.#{queue}=#{latency_ms} "
+          log_msg << "que-qt.#{queue}=#{latency_ms}ms "
         end
 
         logger.debug log_msg unless log_msg.empty?

--- a/lib/judoscale/worker_adapters/que.rb
+++ b/lib/judoscale/worker_adapters/que.rb
@@ -54,7 +54,7 @@ module Judoscale
           latency_ms = 0 if latency_ms < 0
 
           store.push :qt, latency_ms, t, queue
-          log_msg << "que.#{queue}=#{latency_ms} "
+          log_msg << "que-qt.#{queue}=#{latency_ms} "
         end
 
         logger.debug log_msg unless log_msg.empty?

--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -54,7 +54,7 @@ module Judoscale
 
           store.push :qt, latency_ms, Time.now, queue_name
           store.push :qd, depth, Time.now, queue_name
-          log_msg << "sidekiq-qt.#{queue_name}=#{latency_ms} sidekiq-qd.#{queue_name}=#{depth} "
+          log_msg << "sidekiq-qt.#{queue_name}=#{latency_ms}ms sidekiq-qd.#{queue_name}=#{depth} "
 
           if track_long_running_jobs?
             busy_count = busy_counts[queue_name]

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -66,6 +66,16 @@ module Judoscale
             _(app.env["judoscale.queue_time"]).must_be_within_delta 5000, 1
           end
 
+          it "logs debug information about the request and queue time" do
+            use_config debug: true do
+              env["HTTP_X_REQUEST_ID"] = "req-abc-123"
+
+              middleware.call(env)
+
+              _(log_string).must_include "Request queue_time=5000ms network_time=0ms request_id=req-abc-123 size=5"
+            end
+          end
+
           describe "when the request body is large enough to skew the queue time" do
             before { env["rack.input"] = StringIO.new("." * 110_000) }
 

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -72,7 +72,7 @@ module Judoscale
 
               middleware.call(env)
 
-              _(log_string).must_include "Request queue_time=5000ms network_time=0ms request_id=req-abc-123 size=5"
+              _(log_string).must_match %r{Request queue_time=500\dms network_time=0ms request_id=req-abc-123 size=5}
             end
           end
 

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -10,15 +10,7 @@ module Judoscale
     before { setup_env({"DYNO" => "web.1", "JUDOSCALE_URL" => "http://example.com/api/test-token"}) }
 
     describe "#start!" do
-      let(:string_io) { StringIO.new }
-      let(:logger) { ::Logger.new(string_io) }
-
       before {
-        # FIXME: even though the config resets after each test, and the logger is set to the config below,
-        # the proxy included in the Reporter class itself (and a couple other places) is shared and doesn't
-        # get reset anywhere. This ensures it gets re-initialized for each test and uses the configured logger.
-        Reporter.instance.instance_variable_set(:@logger, nil)
-        Config.instance.logger = logger
         stub_request(:post, %r{registrations}).to_return(body: "{}")
       }
       after {
@@ -45,8 +37,8 @@ module Judoscale
           run_reporter_start_thread
         }
 
-        _(string_io.string).must_include "Reporter error: #<RuntimeError: REPORT BOOM!>"
-        _(string_io.string).must_include "lib/judoscale/reporter.rb"
+        _(log_string).must_include "Reporter error: #<RuntimeError: REPORT BOOM!>"
+        _(log_string).must_include "lib/judoscale/reporter.rb"
       end
 
       it "logs exceptions when collecting adapter information" do
@@ -57,8 +49,8 @@ module Judoscale
           run_reporter_start_thread
         }
 
-        _(string_io.string).must_include "Reporter error: #<RuntimeError: ADAPTER BOOM!>"
-        _(string_io.string).must_include "lib/judoscale/reporter.rb"
+        _(log_string).must_include "Reporter error: #<RuntimeError: ADAPTER BOOM!>"
+        _(log_string).must_include "lib/judoscale/reporter.rb"
       end
     end
 

--- a/test/support/log_helpers.rb
+++ b/test/support/log_helpers.rb
@@ -1,0 +1,22 @@
+module LogHelpers
+  @log_io = StringIO.new
+
+  class << self
+    attr_reader :log_io
+  end
+
+  def log_string
+    LogHelpers.log_io.string
+  end
+
+  def clear_log
+    LogHelpers.log_io.reopen
+  end
+
+  def after_teardown
+    clear_log
+    super
+  end
+end
+
+Judoscale::Test.include(LogHelpers)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,7 @@ require "delayed_job_active_record"
 
 module Rails
   def self.logger
-    @logger ||= ::Logger.new("log/test.log")
+    @logger ||= ::Logger.new(LogHelpers.log_io)
   end
 
   def self.version

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -82,6 +82,16 @@ module Judoscale
         _(store.measurements[0].queue_name).must_equal "default"
         _(store.measurements[0].value).must_be_within_delta 0, 5
       end
+
+      it "logs debug information for each queue being collected" do
+        use_config debug: true do
+          Delayable.new.delay(queue: "default").perform
+
+          subject.collect! store
+
+          _(log_string).must_match %r{dj-qt.default=\d+ms}
+        end
+      end
     end
   end
 end

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -41,6 +41,16 @@ module Judoscale
         _(store.measurements[1].queue_name).must_equal "high"
         _(store.measurements[1].value).must_be_within_delta 22222, 5
       end
+
+      it "logs debug information for each queue being collected" do
+        use_config debug: true do
+          enqueue("default", Time.now)
+
+          subject.collect! store
+
+          _(log_string).must_match %r{que-qt.default=\d+ms}
+        end
+      end
     end
   end
 end

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -81,6 +81,21 @@ module Judoscale
         _(store.measurements.size).must_equal 2
         _(store.measurements.map(&:queue_name)).must_equal %w[default low]
       end
+
+      it "logs debug information for each queue being collected" do
+        use_config debug: true do
+          queues = ["default"]
+          size = 2
+
+          ::Resque.stub(:queues, queues) {
+            ::Resque.stub(:size, size) {
+              subject.collect! store
+            }
+          }
+
+          _(log_string).must_match %r{resque-qd.default=2}
+        end
+      end
     end
   end
 end

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -94,6 +94,18 @@ module Judoscale
         _(store.measurements.size).must_equal 4
         _(store.measurements.map(&:queue_name)).must_equal %w[low low default default]
       end
+
+      it "logs debug information for each queue being collected" do
+        use_config debug: true do
+          queues = [SidekiqQueueStub.new(name: "default", latency: 11, size: 1)]
+
+          ::Sidekiq::Queue.stub(:all, queues) {
+            subject.collect! store
+          }
+
+          _(log_string).must_match %r{sidekiq-qt.default=11000ms sidekiq-qd.default=1}
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
There's a few things going on here on separate commits, but I thought it'd make sense to PR them together as they're all about logging improvements.

* Setting up the test logger with a StringIO instance that is reset after each test, so we can more easily test logging going forward and don't need to rely on swapping the configured logger and/or logging to a file.
* Move the request logging out of the Request and into the Middleware, so that it's closer to where it's collected & pushed to the store for later reporting, and works more similarly to the workers.
* Add the `qt` metric identifier as suffix when logging Que info, making it consistent with the others.