### PR TITLE
Remove legacy configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Remove legacy configs: `sidekiq_latency_for_active_jobs`, `latency_for_active_jobs`. ([#22](https://github.com/judoscale/judoscale-ruby/pull/22))
 - Collect a new metric: network time, and expose it to the app via rack env with `judoscale.network_time`. This is currently only available with Puma, and represents the time Puma spent waiting for the request body. ([#20](https://github.com/judoscale/judoscale-ruby/pull/20))
 - Change the `queue_time` rack env value exposed to the app to `judoscale.queue_time`. ([#18](https://github.com/judoscale/judoscale-ruby/pull/18))
 - Drop dev mode. ([#16](https://github.com/judoscale/judoscale-ruby/pull/16))

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -10,9 +10,7 @@ module Judoscale
 
     attr_accessor :report_interval, :logger, :api_base_url, :max_request_size,
       :dyno, :addon_name, :worker_adapters, :debug, :quiet,
-      :track_long_running_jobs, :max_queues,
-      # legacy configs, no longer used
-      :sidekiq_latency_for_active_jobs, :latency_for_active_jobs
+      :track_long_running_jobs, :max_queues
 
     def initialize
       @worker_adapters = prepare_worker_adapters


### PR DESCRIPTION
These have been made legacy for over a year now, since:
90cd58ab18e8511b8b065a0d269cfeae112fee85