### PR TITLE
Check for worker adapter enabled upfront to make sure it is required

### DIFF
--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -83,6 +83,8 @@ module Judoscale
       end
 
       it "logs debug information for each queue being collected" do
+        _(subject).must_be :enabled?
+
         use_config debug: true do
           queues = ["default"]
           size = 2

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -96,6 +96,8 @@ module Judoscale
       end
 
       it "logs debug information for each queue being collected" do
+        _(subject).must_be :enabled?
+
         use_config debug: true do
           queues = [SidekiqQueueStub.new(name: "default", latency: 11, size: 1)]
 


### PR DESCRIPTION
Both Sidekiq and Rescue try to require the respective libraries when we
check if they're enabled, if we don't do that in the test setup,
depending on the order in which tests run, these new logging tests might
randomly fail because the constants aren't defined yet.

This was reproducible with the following seed that happened on CI:

    % be rake TESTOPTS="--seed=61479"

    ...E.....................................................

    Finished in 0.302106s, 188.6755 runs/s, 473.3438 assertions/s.

      1) Error:
    Judoscale::WorkerAdapters::Sidekiq::#collect!#test_0004_logs debug information for each queue being collected:
    NameError: uninitialized constant Sidekiq

Performing an "enabled?" check in those tests fix this issue, and it's
how other tests are also being setup currently.

This should no longer going to be a problem once we move away from the
"enabled?" checks in the future.