### PR TITLE
Test config + ENV vars separately, use config overrides for other tests

### DIFF
--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -66,9 +66,7 @@ module Judoscale
 
       describe "configured to allow debug logs" do
         before {
-          setup_env({"JUDOSCALE_DEBUG" => "true"})
-          # Need to reconfigure the logger with the new ENV setup.
-          Config.instance.logger = original_logger
+          Config.instance.debug = true
         }
 
         it "includes debug logs if enabled and the main logger.level is DEBUG" do

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -30,8 +30,10 @@ module Judoscale
       }
       let(:middleware) { Middleware.new(app) }
 
-      describe "with JUDOSCALE_URL set" do
-        before { setup_env({"JUDOSCALE_URL" => "http://example.com"}) }
+      describe "with the API URL configured" do
+        before {
+          Config.instance.api_base_url = "http://example.com"
+        }
 
         it "passes the request up the middleware stack" do
           middleware.call(env)
@@ -110,8 +112,10 @@ module Judoscale
         end
       end
 
-      describe "without JUDOSCALE_URL set" do
-        before { setup_env({"JUDOSCALE_URL" => nil}) }
+      describe "without the API URL configured" do
+        before {
+          Config.instance.api_base_url = nil
+        }
 
         it "passes the request up the middleware stack" do
           middleware.call(env)

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -7,7 +7,10 @@ require "judoscale/store"
 
 module Judoscale
   describe Reporter do
-    before { setup_env({"DYNO" => "web.1", "JUDOSCALE_URL" => "http://example.com/api/test-token"}) }
+    before {
+      Config.instance.dyno = "web.1"
+      Config.instance.api_base_url = "http://example.com/api/test-token"
+    }
 
     describe "#start!" do
       before {


### PR DESCRIPTION
The config is the only piece that really knows about ENV vars currently,
reading them and setting internal properties as needed. All other pieces
of the code interact directly with the config instead of reading from
the ENV.

Reflect that relationship and encapsulation within the tests as well,
by overriding config values for different test needs to drive behavior,
and leaving the config tests to handle how ENV vars affect the config
object.