### PR TITLE
Allow configuration through a block, simplify resetting config during tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Configure Judoscale through a block: `Judoscale.configure { |config| config.logger = MyLogger.new }`. ([#25](https://github.com/judoscale/judoscale-ruby/pull/25))
 - Remove legacy configs: `sidekiq_latency_for_active_jobs`, `latency_for_active_jobs`. ([#22](https://github.com/judoscale/judoscale-ruby/pull/22))
 - Collect a new metric: network time, and expose it to the app via rack env with `judoscale.network_time`. This is currently only available with Puma, and represents the time Puma spent waiting for the request body. ([#20](https://github.com/judoscale/judoscale-ruby/pull/20))
 - Change the `queue_time` rack env value exposed to the app to `judoscale.queue_time`. ([#18](https://github.com/judoscale/judoscale-ruby/pull/18))

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ If you wish to use a different logger you can set it on the configuration object
 
 ```ruby
 # config/initializers/judoscale.rb
-Judoscale::Config.instance.logger = MyLogger.new
+Judoscale.configure do |config|
+  config.logger = MyLogger.new
+end
 ```
 
 Debug logs are silenced by default because Rails apps default to a DEBUG log level in production, and this gem has _very_ chatty debug logs. If you want to see the debug logs, set `JUDOSCALE_DEBUG` on your Heroku app:
@@ -107,7 +109,9 @@ If you find the gem too chatty even without this, you can quiet it down further:
 
 ```ruby
 # config/initializers/judoscale.rb
-Judoscale::Config.instance.quiet = true
+Judoscale.configure do |config|
+  config.quiet = true
+end
 ```
 
 ## Development

--- a/lib/judoscale.rb
+++ b/lib/judoscale.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
 module Judoscale
+  # Allows configuring Judoscale through a block, usually defined during application initialization.
+  #
+  # Example:
+  #
+  #    Judoscale.configure do |config|
+  #      config.logger = MyLogger.new
+  #    end
+  def self.configure
+    yield Config.instance
+  end
 end
 
+require "judoscale/config"
 require "judoscale/version"
 require "judoscale/railtie" if defined?(Rails::Railtie) && Rails::Railtie.respond_to?(:initializer)

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -9,26 +9,31 @@ module Judoscale
     include Singleton
 
     attr_accessor :report_interval, :logger, :api_base_url, :max_request_size,
-      :dyno, :addon_name, :worker_adapters, :debug, :quiet,
-      :track_long_running_jobs, :max_queues
+      :dyno, :addon_name, :debug, :quiet, :track_long_running_jobs, :max_queues
+    attr_reader :worker_adapters
 
     def initialize
       reset
     end
 
     def reset
-      @worker_adapters = prepare_worker_adapters
+      self.worker_adapters = ENV["JUDOSCALE_WORKER_ADAPTER"] || DEFAULT_WORKER_ADAPTERS
 
       # Allow the add-on name to be configured - needed for testing
       @addon_name = ENV["JUDOSCALE_ADDON"] || "JUDOSCALE"
       @api_base_url = ENV["#{@addon_name}_URL"]
       @debug = ENV["JUDOSCALE_DEBUG"] == "true"
+      @quiet = false
       @track_long_running_jobs = ENV["JUDOSCALE_LONG_JOBS"] == "true"
       @max_queues = ENV.fetch("JUDOSCALE_MAX_QUEUES", 50).to_i
       @max_request_size = 100_000 # ignore request payloads over 100k since they skew the queue times
       @report_interval = 10
       @logger = defined?(Rails) ? Rails.logger : ::Logger.new($stdout)
       @dyno = ENV["DYNO"]
+    end
+
+    def worker_adapters=(adapters_config)
+      @worker_adapters = prepare_worker_adapters(adapters_config)
     end
 
     def to_s
@@ -44,8 +49,8 @@ module Judoscale
 
     private
 
-    def prepare_worker_adapters
-      adapter_names = (ENV["JUDOSCALE_WORKER_ADAPTER"] || DEFAULT_WORKER_ADAPTERS).split(",")
+    def prepare_worker_adapters(adapters_config)
+      adapter_names = adapters_config.split(",")
       adapter_names.map do |adapter_name|
         require "judoscale/worker_adapters/#{adapter_name}"
         adapter_constant_name = adapter_name.capitalize.gsub(/(?:_)(.)/i) { $1.upcase }

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -13,6 +13,10 @@ module Judoscale
       :track_long_running_jobs, :max_queues
 
     def initialize
+      reset
+    end
+
+    def reset
       @worker_adapters = prepare_worker_adapters
 
       # Allow the add-on name to be configured - needed for testing
@@ -23,7 +27,7 @@ module Judoscale
       @max_queues = ENV.fetch("JUDOSCALE_MAX_QUEUES", 50).to_i
       @max_request_size = 100_000 # ignore request payloads over 100k since they skew the queue times
       @report_interval = 10
-      @logger ||= defined?(Rails) ? Rails.logger : ::Logger.new($stdout)
+      @logger = defined?(Rails) ? Rails.logger : ::Logger.new($stdout)
       @dyno = ENV["DYNO"]
     end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -11,9 +11,9 @@ module Judoscale
     let(:original_logger) { ::Logger.new(string_io) }
     let(:messages) { string_io.string }
 
-    before do
-      Config.instance.logger = original_logger
-    end
+    before {
+      Judoscale.configure { |config| config.logger = original_logger }
+    }
 
     describe "#error" do
       it "delegates to the original logger, prepending Judoscale" do
@@ -66,7 +66,7 @@ module Judoscale
 
       describe "configured to allow debug logs" do
         before {
-          Config.instance.debug = true
+          Judoscale.configure { |config| config.debug = true }
         }
 
         it "includes debug logs if enabled and the main logger.level is DEBUG" do

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -32,7 +32,7 @@ module Judoscale
 
       describe "with the API URL configured" do
         before {
-          Config.instance.api_base_url = "http://example.com"
+          Judoscale.configure { |config| config.api_base_url = "http://example.com" }
         }
 
         it "passes the request up the middleware stack" do
@@ -114,7 +114,7 @@ module Judoscale
 
       describe "without the API URL configured" do
         before {
-          Config.instance.api_base_url = nil
+          Judoscale.configure { |config| config.api_base_url = nil }
         }
 
         it "passes the request up the middleware stack" do

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -8,8 +8,10 @@ require "judoscale/store"
 module Judoscale
   describe Reporter do
     before {
-      Config.instance.dyno = "web.1"
-      Config.instance.api_base_url = "http://example.com/api/test-token"
+      Judoscale.configure do |config|
+        config.dyno = "web.1"
+        config.api_base_url = "http://example.com/api/test-token"
+      end
     }
 
     describe "#start!" do

--- a/test/support/config_helpers.rb
+++ b/test/support/config_helpers.rb
@@ -25,7 +25,7 @@ module ConfigHelpers
 
   # Reset config instance after each test to ensure changes don't leak to other tests.
   def after_teardown
-    Singleton.__init__(Judoscale::Config)
+    Judoscale::Config.instance.reset
     super
   end
 end

--- a/test/support/env_helpers.rb
+++ b/test/support/env_helpers.rb
@@ -33,8 +33,7 @@ module EnvHelpers
     end
 
     # Force config to load with the swapped ENV.
-    Singleton.__init__(Judoscale::Config)
-    Judoscale::Config.instance
+    Judoscale::Config.instance.reset
   end
 
   # Restores ENV values to their original state. (from when `setup_env` was called, see it for more info.)


### PR DESCRIPTION
This creates a public interface for configuring Judoscale through a block, commonly used for setting up libraries with different configs, and will facilitate moving away from some of the ENV var configs in favor of suggesting this block config, where customers can then rely on ENV vars if they decide to do so.

It also exposes a way to reset the config so we can more easily do that between tests instead of relying on the  `Singleton.__init__` approach to clear out the cached singleton instance.

I have updated the two places in the doc that used direct `Config.instance` access, but not touched the "Configuration" section as that is still referring to some of the ENV vars supported. I think the next step would be to remove support for those ENV vars and update the Readme there to show the new configuration block way.