### PR TITLE
Move away from ENV var config in favor of the new initializer with a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Drop support for ENV vars `JUDOSCALE_WORKER_ADAPTER`, `JUDOSCALE_LONG_JOBS`, and `JUDOSCALE_MAX_QUEUES`, in favor of using the new block config format. ([#26](https://github.com/judoscale/judoscale-ruby/pull/26))
 - Configure Judoscale through a block: `Judoscale.configure { |config| config.logger = MyLogger.new }`. ([#25](https://github.com/judoscale/judoscale-ruby/pull/25))
 - Remove legacy configs: `sidekiq_latency_for_active_jobs`, `latency_for_active_jobs`. ([#22](https://github.com/judoscale/judoscale-ruby/pull/22))
 - Collect a new metric: network time, and expose it to the app via rack env with `judoscale.network_time`. This is currently only available with Puma, and represents the time Puma spent waiting for the request body. ([#20](https://github.com/judoscale/judoscale-ruby/pull/20))

--- a/README.md
+++ b/README.md
@@ -40,27 +40,49 @@ Judoscale aggregates and stores this information to power the autoscaling algori
 
 ## Configuration
 
-Most Judoscale configurations are handled via the settings page on your Judoscale dashboard, but there a few ways you can directly change the behavior of the agent via environment variables:
+Most Judoscale configurations are handled via the settings page on your Judoscale dashboard, but there a few ways you can directly change the behavior of the agent by creating an initializer in your app like the following:
 
-- `JUDOSCALE_DEBUG` - Enables debug logging. See more in the [logging](#logging) section below.
-- `JUDOSCALE_WORKER_ADAPTER` - Overrides the available worker adapters. See more in the [worker adapters](#worker-adapters) section below.
-- `JUDOSCALE_LONG_JOBS` - Enables reporting for active workers. See [Handling Long-Running Background Jobs](https://judoscale.com/docs/long-running-jobs/) in the Judoscale docs for more.
-- `JUDOSCALE_MAX_QUEUES` - Worker metrics will only report up to 50 queues by default. If you have more than 50 queues, you'll need to configure this settings or reduce your number of queues.
+```ruby
+# config/initializers/judoscale.rb
+Judoscale.configure do |config|
+  # configure Judoscale here, more on each configuration option below.
+
+  # Enables debug logging. This can also be enabled/disabled via the JUDOSCALE_DEBUG environment variable.
+  # See more in the [logging](#logging) section below.
+  config.debug = true
+
+  # Overrides the available worker adapters. See more in the [worker adapters](#worker-adapters) section below.
+  config.worker_adapters = "sidekiq,resque"
+
+  # Enables reporting for active workers.
+  # See [Handling Long-Running Background Jobs](https://judoscale.com/docs/long-running-jobs/) in the Judoscale docs for more.
+  config.track_long_running_jobs = true
+
+  # Worker metrics will only report up to 50 queues by default. If you have more than
+  # 50 queues, you'll need to configure this settings or reduce your number of queues.
+  config.max_queues = 100
+end
+```
 
 ## Worker adapters
 
 Judoscale supports autoscaling worker dynos. Out of the box, four job backends are supported: Sidekiq, Resque, Delayed Job, and Que. The agent will automatically enable the appropriate worker adapter based on what you have installed in your app.
 
-In some scenarios you might want to override this behavior. Let's say you have both Sidekiq and Resque installed 🤷‍♂️, but you only want Judoscale to collect metrics for Sidekiq. Here's how you'd override that:
+In some scenarios you might want to override this behavior. Let's say you have both Sidekiq and Resque installed 🤷‍♂️, but you only want Judoscale to collect metrics for Sidekiq. You can override that via configuration:
 
-```
-heroku config:add JUDOSCALE_WORKER_ADAPTER=sidekiq
+```ruby
+Judoscale.configure do |config|
+  config.worker_adapters = "sidekiq"
+end
 ```
 
 You can also disable collection of worker metrics altogether:
 
 ```
-heroku config:add JUDOSCALE_WORKER_ADAPTER=""
+Judoscale.configure do |config|
+  config.worker_adapters = ""
+end
+
 ```
 
 It's also possible to write a custom worker adapter. See [these docs](https://judoscale.com/docs/custom-worker-adapter/) for details.
@@ -102,7 +124,7 @@ end
 Debug logs are silenced by default because Rails apps default to a DEBUG log level in production, and this gem has _very_ chatty debug logs. If you want to see the debug logs, set `JUDOSCALE_DEBUG` on your Heroku app:
 
 ```
-heroku config:add JUDOSCALE_DEBUG=true
+heroku config:set JUDOSCALE_DEBUG=true
 ```
 
 If you find the gem too chatty even without this, you can quiet it down further:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Judoscale.configure do |config|
   config.debug = true
 
   # Overrides the available worker adapters. See more in the [worker adapters](#worker-adapters) section below.
-  config.worker_adapters = "sidekiq,resque"
+  config.worker_adapters = %i[sidekiq resque]
 
   # Enables reporting for active workers.
   # See [Handling Long-Running Background Jobs](https://judoscale.com/docs/long-running-jobs/) in the Judoscale docs for more.
@@ -71,16 +71,18 @@ Judoscale supports autoscaling worker dynos. Out of the box, four job backends a
 In some scenarios you might want to override this behavior. Let's say you have both Sidekiq and Resque installed 🤷‍♂️, but you only want Judoscale to collect metrics for Sidekiq. You can override that via configuration:
 
 ```ruby
+# config/initializers/judoscale.rb
 Judoscale.configure do |config|
-  config.worker_adapters = "sidekiq"
+  config.worker_adapters = [:sidekiq]
 end
 ```
 
 You can also disable collection of worker metrics altogether:
 
-```
+```ruby
+# config/initializers/judoscale.rb
 Judoscale.configure do |config|
-  config.worker_adapters = ""
+  config.worker_adapters = []
 end
 
 ```

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -4,7 +4,7 @@ require "singleton"
 
 module Judoscale
   class Config
-    DEFAULT_WORKER_ADAPTERS = "sidekiq,delayed_job,que,resque"
+    DEFAULT_WORKER_ADAPTERS = %i[sidekiq delayed_job que resque]
 
     include Singleton
 
@@ -48,9 +48,9 @@ module Judoscale
 
     private
 
-    def prepare_worker_adapters(adapters_config)
-      adapter_names = adapters_config.split(",")
+    def prepare_worker_adapters(adapter_names)
       adapter_names.map do |adapter_name|
+        adapter_name = adapter_name.to_s
         require "judoscale/worker_adapters/#{adapter_name}"
         adapter_constant_name = adapter_name.capitalize.gsub(/(?:_)(.)/i) { $1.upcase }
         WorkerAdapters.const_get(adapter_constant_name).instance

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -9,27 +9,31 @@ module Judoscale
     include Singleton
 
     attr_accessor :report_interval, :logger, :api_base_url, :max_request_size,
-      :dyno, :addon_name, :debug, :quiet, :track_long_running_jobs, :max_queues
-    attr_reader :worker_adapters
+      :dyno, :debug, :quiet, :track_long_running_jobs, :max_queues
+    attr_reader :addon_name, :worker_adapters
 
     def initialize
       reset
     end
 
     def reset
-      self.worker_adapters = ENV["JUDOSCALE_WORKER_ADAPTER"] || DEFAULT_WORKER_ADAPTERS
+      self.worker_adapters = DEFAULT_WORKER_ADAPTERS
 
       # Allow the add-on name to be configured - needed for testing
-      @addon_name = ENV["JUDOSCALE_ADDON"] || "JUDOSCALE"
-      @api_base_url = ENV["#{@addon_name}_URL"]
+      self.addon_name = ENV["JUDOSCALE_ADDON"] || "JUDOSCALE"
+      @dyno = ENV["DYNO"]
       @debug = ENV["JUDOSCALE_DEBUG"] == "true"
       @quiet = false
-      @track_long_running_jobs = ENV["JUDOSCALE_LONG_JOBS"] == "true"
-      @max_queues = ENV.fetch("JUDOSCALE_MAX_QUEUES", 50).to_i
+      @track_long_running_jobs = false
+      @max_queues = 50
       @max_request_size = 100_000 # ignore request payloads over 100k since they skew the queue times
       @report_interval = 10
       @logger = defined?(Rails) ? Rails.logger : ::Logger.new($stdout)
-      @dyno = ENV["DYNO"]
+    end
+
+    def addon_name=(name)
+      @addon_name = name
+      @api_base_url = ENV["#{@addon_name}_URL"]
     end
 
     def worker_adapters=(adapters_config)

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -10,7 +10,7 @@ module Judoscale
 
     attr_accessor :report_interval, :logger, :api_base_url, :max_request_size,
       :dyno, :debug, :quiet, :track_long_running_jobs, :max_queues
-    attr_reader :addon_name, :worker_adapters
+    attr_reader :worker_adapters
 
     def initialize
       reset
@@ -19,8 +19,8 @@ module Judoscale
     def reset
       self.worker_adapters = DEFAULT_WORKER_ADAPTERS
 
-      # Allow the add-on name to be configured - needed for testing
-      self.addon_name = ENV["JUDOSCALE_ADDON"] || "JUDOSCALE"
+      # Allow the API URL to be configured - needed for testing.
+      @api_base_url = ENV["JUDOSCALE_URL"]
       @dyno = ENV["DYNO"]
       @debug = ENV["JUDOSCALE_DEBUG"] == "true"
       @quiet = false
@@ -29,11 +29,6 @@ module Judoscale
       @max_request_size = 100_000 # ignore request payloads over 100k since they skew the queue times
       @report_interval = 10
       @logger = defined?(Rails) ? Rails.logger : ::Logger.new($stdout)
-    end
-
-    def addon_name=(name)
-      @addon_name = name
-      @api_base_url = ENV["#{@addon_name}_URL"]
     end
 
     def worker_adapters=(adapters_config)

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -20,7 +20,7 @@ module Judoscale
       dyno_num = config.dyno.to_s.split(".").last.to_i
 
       if !config.api_base_url
-        logger.info "Reporter not started: #{config.addon_name}_URL is not set"
+        logger.info "Reporter not started: JUDOSCALE_URL is not set"
         return
       end
 

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -4,6 +4,7 @@ require "singleton"
 require "judoscale/logger"
 require "judoscale/autoscale_api"
 require "judoscale/registration"
+require "judoscale/worker_adapters"
 
 module Judoscale
   class Reporter
@@ -16,7 +17,7 @@ module Judoscale
 
     def start!(config, store)
       @started = true
-      worker_adapters = config.worker_adapters.select(&:enabled?)
+      worker_adapters = WorkerAdapters.load_adapters(config.worker_adapters).select(&:enabled?)
       dyno_num = config.dyno.to_s.split(".").last.to_i
 
       if !config.api_base_url

--- a/lib/judoscale/worker_adapters.rb
+++ b/lib/judoscale/worker_adapters.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Judoscale
+  module WorkerAdapters
+    def self.load_adapters(adapter_names)
+      adapter_names.map do |adapter_name|
+        adapter_name = adapter_name.to_s
+        require "judoscale/worker_adapters/#{adapter_name}"
+        adapter_constant_name = adapter_name.capitalize.gsub(/(?:_)(.)/i) { $1.upcase }
+        WorkerAdapters.const_get(adapter_constant_name).instance
+      end
+    end
+  end
+end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -55,7 +55,7 @@ module Judoscale
         config.max_queues = 100
         config.max_request_size = 50_000
         config.report_interval = 20
-        config.worker_adapters = "sidekiq,resque"
+        config.worker_adapters = [:sidekiq, :resque]
       end
 
       config = Config.instance

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -8,7 +8,6 @@ module Judoscale
     it "initializes the config from default heroku ENV vars and other sensible defaults" do
       use_env "DYNO" => "web.1", "JUDOSCALE_URL" => "https://example.com" do
         config = Config.instance
-        _(config.addon_name).must_equal "JUDOSCALE"
         _(config.api_base_url).must_equal "https://example.com"
         _(config.dyno).must_equal "web.1"
         _(config.debug).must_equal false
@@ -28,17 +27,15 @@ module Judoscale
       end
     end
 
-    it "allows ENV vars config overrides for the addon name, debug, and url (automatically set via the addon name)" do
+    it "allows ENV vars config overrides for the debug and URL" do
       env = {
         "DYNO" => "web.2",
-        "JUDOSCALE_ADDON" => "JUDOSCALE_CUSTOM",
-        "JUDOSCALE_CUSTOM_URL" => "https://custom.example.com",
+        "JUDOSCALE_URL" => "https://custom.example.com",
         "JUDOSCALE_DEBUG" => "true"
       }
 
       use_env env do
         config = Config.instance
-        _(config.addon_name).must_equal "JUDOSCALE_CUSTOM"
         _(config.api_base_url).must_equal "https://custom.example.com"
         _(config.dyno).must_equal "web.2"
         _(config.debug).must_equal true
@@ -50,7 +47,6 @@ module Judoscale
 
       Judoscale.configure do |config|
         config.dyno = "web.3"
-        config.addon_name = "JUDOSCALE_BLOCK"
         config.api_base_url = "https://block.example.com"
         config.debug = true
         config.quiet = true
@@ -63,7 +59,6 @@ module Judoscale
       end
 
       config = Config.instance
-      _(config.addon_name).must_equal "JUDOSCALE_BLOCK"
       _(config.api_base_url).must_equal "https://block.example.com"
       _(config.dyno).must_equal "web.3"
       _(config.debug).must_equal true
@@ -78,18 +73,6 @@ module Judoscale
         WorkerAdapters::Resque,
         WorkerAdapters::Sidekiq
       ]
-    end
-
-    it "allows configuring the addon name via a block, reading the API url from the ENV based on the name" do
-      use_env "DYNO" => "web.2", "JUDOSCALE_CUSTOM_URL" => "https://custom.example.com" do
-        Judoscale.configure do |config|
-          config.addon_name = "JUDOSCALE_CUSTOM"
-        end
-
-        config = Config.instance
-        _(config.addon_name).must_equal "JUDOSCALE_CUSTOM"
-        _(config.api_base_url).must_equal "https://custom.example.com"
-      end
     end
 
     private

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -17,13 +17,7 @@ module Judoscale
         _(config.max_request_size).must_equal 100_000
         _(config.report_interval).must_equal 10
         _(config.track_long_running_jobs).must_equal false
-
-        config_must_match_worker_adapters config, [
-          WorkerAdapters::DelayedJob,
-          WorkerAdapters::Que,
-          WorkerAdapters::Resque,
-          WorkerAdapters::Sidekiq
-        ]
+        _(config.worker_adapters).must_equal %i[sidekiq delayed_job que resque]
       end
     end
 
@@ -68,20 +62,7 @@ module Judoscale
       _(config.max_request_size).must_equal 50_000
       _(config.report_interval).must_equal 20
       _(config.track_long_running_jobs).must_equal true
-
-      config_must_match_worker_adapters config, [
-        WorkerAdapters::Resque,
-        WorkerAdapters::Sidekiq
-      ]
-    end
-
-    private
-
-    def config_must_match_worker_adapters(config, worker_adapter_classes)
-      configured_worker_adapters_object_ids = config.worker_adapters.map(&:object_id)
-      expected_worker_adapters_object_ids = worker_adapter_classes.map { |w| w.instance.object_id }
-
-      _(configured_worker_adapters_object_ids.sort).must_equal expected_worker_adapters_object_ids.sort
+      _(config.worker_adapters).must_equal %i[sidekiq resque]
     end
   end
 end

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -47,7 +47,7 @@ module Judoscale
       end
 
       it "logs exceptions when collecting adapter information" do
-        enabled_adapter = Config.instance.worker_adapters.find(&:enabled?)
+        enabled_adapter = WorkerAdapters.load_adapters(Config.instance.worker_adapters).find(&:enabled?)
         _(enabled_adapter).wont_be :nil?
 
         enabled_adapter.stub(:collect!, ->(*) { raise "ADAPTER BOOM!" }) {


### PR DESCRIPTION
Judoscale will no longer support ENV vars for most configurations, instead the documentation will suggest people to create a config initializer to tweak the various config options available.

One exception to that is going to be the JUDOSCALE_DEBUG, or `debug` config option. We want customers to be able to set that on the fly without having to setup a config file or deploy the app, since that's been very helpful to support / troubleshooting purposes, so this ENV var will continue to be supported.

This also drops support for the `addon_name` config in favor of setting the API URL in the config block directly, as well as storing the raw list of adapters and lazily loading them with the reporter starting to avoid eagerly loading all the default adapters before the user had a chance to configure it.