### PR TITLE
Refactor worker adapters introducing a "Base" class that they all inherit from

### DIFF
--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -8,6 +8,16 @@ module Judoscale
       include Judoscale::Logger
       include Singleton
 
+      attr_writer :queues
+
+      def queues
+        # Track the known queues so we can continue reporting on queues that don't
+        # have enqueued jobs at the time of reporting.
+        # Assume a "default" queue on all worker adapters so we always report *something*,
+        # even when nothing is enqueued.
+        @queues ||= Set.new(["default"])
+      end
+
       def enabled?
         false
       end

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -24,6 +24,12 @@ module Judoscale
 
       def collect!(store)
       end
+
+      private
+
+      def track_long_running_jobs?
+        Config.instance.track_long_running_jobs
+      end
     end
   end
 end

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "judoscale/logger"
+
+module Judoscale
+  module WorkerAdapters
+    class Base
+      include Judoscale::Logger
+      include Singleton
+
+      def enabled?
+        false
+      end
+
+      def collect!(store)
+      end
+    end
+  end
+end

--- a/lib/judoscale/worker_adapters/delayed_job.rb
+++ b/lib/judoscale/worker_adapters/delayed_job.rb
@@ -71,10 +71,6 @@ module Judoscale
 
       private
 
-      def track_long_running_jobs?
-        Config.instance.track_long_running_jobs
-      end
-
       def select_rows(sql)
         # This ensures the agent doesn't hold onto a DB connection any longer than necessary
         ActiveRecord::Base.connection_pool.with_connection { |c| c.select_rows(sql) }

--- a/lib/judoscale/worker_adapters/delayed_job.rb
+++ b/lib/judoscale/worker_adapters/delayed_job.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-require "judoscale/logger"
+require "judoscale/worker_adapters/base"
 
 module Judoscale
   module WorkerAdapters
-    class DelayedJob
-      include Judoscale::Logger
-      include Singleton
-
+    class DelayedJob < Base
       attr_writer :queues
 
       def enabled?

--- a/lib/judoscale/worker_adapters/delayed_job.rb
+++ b/lib/judoscale/worker_adapters/delayed_job.rb
@@ -27,11 +27,7 @@ module Judoscale
 
         run_at_by_queue = select_rows(sql).to_h
 
-        # Don't collect worker metrics if there are unreasonable number of queues
-        if run_at_by_queue.size > Config.instance.max_queues
-          logger.warn "Skipping DelayedJob metrics - #{run_at_by_queue.size} queues exceeds the #{Config.instance.max_queues} queue limit"
-          return
-        end
+        return if number_of_queues_to_collect_exceeded_limit?(run_at_by_queue)
 
         self.queues |= run_at_by_queue.keys
 

--- a/lib/judoscale/worker_adapters/que.rb
+++ b/lib/judoscale/worker_adapters/que.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-require "judoscale/logger"
+require "judoscale/worker_adapters/base"
 
 module Judoscale
   module WorkerAdapters
-    class Que
-      include Judoscale::Logger
-      include Singleton
-
+    class Que < Base
       attr_writer :queues
 
       def queues

--- a/lib/judoscale/worker_adapters/que.rb
+++ b/lib/judoscale/worker_adapters/que.rb
@@ -5,16 +5,6 @@ require "judoscale/worker_adapters/base"
 module Judoscale
   module WorkerAdapters
     class Que < Base
-      attr_writer :queues
-
-      def queues
-        # Track the known queues so we can continue reporting on queues that don't
-        # have enqueued jobs at the time of reporting.
-        # Assume a "default" queue so we always report *something*, even when nothing
-        # is enqueued.
-        @queues ||= Set.new(["default"])
-      end
-
       def enabled?
         if defined?(::Que)
           logger.info "Que enabled (#{::ActiveRecord::Base.default_timezone})"

--- a/lib/judoscale/worker_adapters/que.rb
+++ b/lib/judoscale/worker_adapters/que.rb
@@ -26,11 +26,7 @@ module Judoscale
 
         run_at_by_queue = select_rows(sql).to_h
 
-        # Don't collect worker metrics if there are unreasonable number of queues
-        if run_at_by_queue.size > Config.instance.max_queues
-          logger.warn "Skipping Que metrics - #{run_at_by_queue.size} queues exceeds the #{Config.instance.max_queues} queue limit"
-          return
-        end
+        return if number_of_queues_to_collect_exceeded_limit?(run_at_by_queue)
 
         self.queues |= run_at_by_queue.keys
 

--- a/lib/judoscale/worker_adapters/resque.rb
+++ b/lib/judoscale/worker_adapters/resque.rb
@@ -17,11 +17,7 @@ module Judoscale
         log_msg = +""
         current_queues = ::Resque.queues
 
-        # Don't collect worker metrics if there are unreasonable number of queues
-        if current_queues.size > Config.instance.max_queues
-          logger.warn "Skipping Resque metrics - #{current_queues.size} queues exceeds the #{Config.instance.max_queues} queue limit"
-          return
-        end
+        return if number_of_queues_to_collect_exceeded_limit?(current_queues)
 
         # Ensure we continue to collect metrics for known queue names, even when nothing is
         # enqueued at the time. Without this, it will appears that the agent is no longer reporting.

--- a/lib/judoscale/worker_adapters/resque.rb
+++ b/lib/judoscale/worker_adapters/resque.rb
@@ -5,12 +5,6 @@ require "judoscale/worker_adapters/base"
 module Judoscale
   module WorkerAdapters
     class Resque < Base
-      attr_writer :queues
-
-      def queues
-        @queues ||= ["default"]
-      end
-
       def enabled?
         require "resque"
         logger.info "Resque enabled"

--- a/lib/judoscale/worker_adapters/resque.rb
+++ b/lib/judoscale/worker_adapters/resque.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-require "judoscale/logger"
+require "judoscale/worker_adapters/base"
 
 module Judoscale
   module WorkerAdapters
-    class Resque
-      include Judoscale::Logger
-      include Singleton
-
+    class Resque < Base
       attr_writer :queues
 
       def queues

--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -23,11 +23,7 @@ module Judoscale
           obj[queue.name] = queue
         end
 
-        # Don't collect worker metrics if there are unreasonable number of queues
-        if queues_by_name.size > Config.instance.max_queues
-          logger.warn "Skipping Sidekiq metrics - #{queues_by_name.size} queues exceeds the #{Config.instance.max_queues} queue limit"
-          return
-        end
+        return if number_of_queues_to_collect_exceeded_limit?(queues_by_name)
 
         # Ensure we continue to collect metrics for known queue names, even when nothing is
         # enqueued at the time. Without this, it will appear that the agent is no longer reporting.

--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -5,8 +5,6 @@ require "judoscale/worker_adapters/base"
 module Judoscale
   module WorkerAdapters
     class Sidekiq < Base
-      attr_writer :queues
-
       def enabled?
         require "sidekiq/api"
 
@@ -36,7 +34,7 @@ module Judoscale
         queues.each do |queue_name|
           queues_by_name[queue_name] ||= ::Sidekiq::Queue.new(queue_name)
         end
-        self.queues = queues_by_name.keys
+        self.queues |= queues_by_name.keys
 
         if track_long_running_jobs?
           busy_counts = Hash.new { |h, k| h[k] = 0 }
@@ -64,10 +62,6 @@ module Judoscale
       end
 
       private
-
-      def queues
-        @queues ||= ["default"]
-      end
 
       def track_long_running_jobs?
         Config.instance.track_long_running_jobs

--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -60,12 +60,6 @@ module Judoscale
 
         logger.debug log_msg
       end
-
-      private
-
-      def track_long_running_jobs?
-        Config.instance.track_long_running_jobs
-      end
     end
   end
 end

--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-require "judoscale/logger"
+require "judoscale/worker_adapters/base"
 
 module Judoscale
   module WorkerAdapters
-    class Sidekiq
-      include Judoscale::Logger
-      include Singleton
-
+    class Sidekiq < Base
       attr_writer :queues
 
       def enabled?

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -92,6 +92,17 @@ module Judoscale
           _(log_string).must_match %r{dj-qt.default=\d+ms}
         end
       end
+
+      it "skips metrics collection if exceeding max queues configured limit" do
+        use_config max_queues: 2 do
+          %w[low default high].each { |queue| Delayable.new.delay(queue: queue).perform }
+
+          subject.collect! store
+
+          _(store.measurements.size).must_equal 0
+          _(log_string).must_match %r{Skipping DelayedJob metrics - 3 queues exceeds the 2 queue limit}
+        end
+      end
     end
   end
 end

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -51,6 +51,17 @@ module Judoscale
           _(log_string).must_match %r{que-qt.default=\d+ms}
         end
       end
+
+      it "skips metrics collection if exceeding max queues configured limit" do
+        use_config max_queues: 2 do
+          %w[low default high].each { |queue| enqueue(queue, Time.now) }
+
+          subject.collect! store
+
+          _(store.measurements.size).must_equal 0
+          _(log_string).must_match %r{Skipping Que metrics - 3 queues exceeds the 2 queue limit}
+        end
+      end
     end
   end
 end

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -98,6 +98,21 @@ module Judoscale
           _(log_string).must_match %r{resque-qd.default=2}
         end
       end
+
+      it "skips metrics collection if exceeding max queues configured limit" do
+        _(subject).must_be :enabled?
+
+        use_config max_queues: 2 do
+          queues = %w[low default high]
+
+          ::Resque.stub(:queues, queues) {
+            subject.collect! store
+          }
+
+          _(store.measurements.size).must_equal 0
+          _(log_string).must_match %r{Skipping Resque metrics - 3 queues exceeds the 2 queue limit}
+        end
+      end
     end
   end
 end

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -92,7 +92,7 @@ module Judoscale
         }
 
         _(store.measurements.size).must_equal 4
-        _(store.measurements.map(&:queue_name)).must_equal %w[low low default default]
+        _(store.measurements.map(&:queue_name)).must_equal %w[default default low low]
       end
 
       it "logs debug information for each queue being collected" do


### PR DESCRIPTION
This allows us to create a base implementation to help document the worker adapters public API, and start sharing some code among them that can be useful for future adapter implementations as well.

It will also facilitate the introduction of more advanced queue filtering, and per-adapter configuration, coming later.