### PR TITLE
Fix issue with sidekiq and track long running jobs, cover feature with some tests

### DIFF
--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -49,7 +49,7 @@ module Judoscale
 
           if track_long_running_jobs?
             busy_count = busy_counts[queue_name]
-            store.push busy_count, Time.now, queue_name, :busy
+            store.push :busy, busy_count, Time.now, queue_name
             log_msg << "sidekiq-busy.#{queue_name}=#{busy_count} "
           end
         end


### PR DESCRIPTION
I came across an issue with sidekiq and long running jobs, due to the recent changes to the measurement/metric identifier, making it required and changing the order of those arguments. It looks like I forgot this one place and the test help caught it.

I went ahead and added more tests for sidekiq & delayed job around that feature to cover our bases as we do further changes/refactorings on that code later on.