### PR TITLE
Create per-adapter configuration of `max_queues` and `track_long_running_jobs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
-- Allow per-adapter configuration of `max_queues`, dropping support for the global `max_queues` configuration. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))
+- Allow per-adapter configuration of `max_queues` and `track_long_running_jobs`, dropping support for the global configurations. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))
 - Drop support for ENV vars `JUDOSCALE_WORKER_ADAPTER`, `JUDOSCALE_LONG_JOBS`, and `JUDOSCALE_MAX_QUEUES`, in favor of using the new block config format. ([#26](https://github.com/judoscale/judoscale-ruby/pull/26))
 - Configure Judoscale through a block: `Judoscale.configure { |config| config.logger = MyLogger.new }`. ([#25](https://github.com/judoscale/judoscale-ruby/pull/25))
 - Remove legacy configs: `sidekiq_latency_for_active_jobs`, `latency_for_active_jobs`. ([#22](https://github.com/judoscale/judoscale-ruby/pull/22))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Allow per-adapter configuration of `max_queues`, dropping support for the global `max_queues` configuration. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))
 - Drop support for ENV vars `JUDOSCALE_WORKER_ADAPTER`, `JUDOSCALE_LONG_JOBS`, and `JUDOSCALE_MAX_QUEUES`, in favor of using the new block config format. ([#26](https://github.com/judoscale/judoscale-ruby/pull/26))
 - Configure Judoscale through a block: `Judoscale.configure { |config| config.logger = MyLogger.new }`. ([#25](https://github.com/judoscale/judoscale-ruby/pull/25))
 - Remove legacy configs: `sidekiq_latency_for_active_jobs`, `latency_for_active_jobs`. ([#22](https://github.com/judoscale/judoscale-ruby/pull/22))

--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ Judoscale.configure do |config|
 
   # Overrides the available worker adapters. See more in the [worker adapters](#worker-adapters) section below.
   config.worker_adapters = %i[sidekiq resque]
-
-  # Enables reporting for active workers.
-  # See [Handling Long-Running Background Jobs](https://judoscale.com/docs/long-running-jobs/) in the Judoscale docs for more.
-  config.track_long_running_jobs = true
 end
 ```
 
@@ -90,6 +86,10 @@ Judoscale.configure do |config|
   # Worker metrics will only report up to 50 queues by default. If you have more than 50 queues,
   # you'll need to configure this settings for the specific worker adapter or reduce your number of queues.
   config.sidekiq.max_queues = 100
+
+  # Enables reporting for active workers.
+  # See [Handling Long-Running Background Jobs](https://judoscale.com/docs/long-running-jobs/) in the Judoscale docs for more.
+  config.sidekiq.track_long_running_jobs = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ Judoscale.configure do |config|
   # Enables reporting for active workers.
   # See [Handling Long-Running Background Jobs](https://judoscale.com/docs/long-running-jobs/) in the Judoscale docs for more.
   config.track_long_running_jobs = true
-
-  # Worker metrics will only report up to 50 queues by default. If you have more than
-  # 50 queues, you'll need to configure this settings or reduce your number of queues.
-  config.max_queues = 100
 end
 ```
 
@@ -84,7 +80,17 @@ You can also disable collection of worker metrics altogether:
 Judoscale.configure do |config|
   config.worker_adapters = []
 end
+```
 
+Each worker adapter have its own set of configurations as well:
+
+```ruby
+# config/initializers/judoscale.rb
+Judoscale.configure do |config|
+  # Worker metrics will only report up to 50 queues by default. If you have more than 50 queues,
+  # you'll need to configure this settings for the specific worker adapter or reduce your number of queues.
+  config.sidekiq.max_queues = 100
+end
 ```
 
 It's also possible to write a custom worker adapter. See [these docs](https://judoscale.com/docs/custom-worker-adapter/) for details.

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -7,18 +7,19 @@ module Judoscale
     DEFAULT_WORKER_ADAPTERS = %i[sidekiq delayed_job que resque]
 
     class WorkerAdapterConfig
-      attr_accessor :max_queues
+      attr_accessor :max_queues, :track_long_running_jobs
 
       def initialize(adapter_name)
         @adapter_name = adapter_name
         @max_queues = 50
+        @track_long_running_jobs = false
       end
     end
 
     include Singleton
 
     attr_accessor :report_interval, :logger, :api_base_url, :max_request_size,
-      :dyno, :debug, :quiet, :track_long_running_jobs, :worker_adapters, *DEFAULT_WORKER_ADAPTERS
+      :dyno, :debug, :quiet, :worker_adapters, *DEFAULT_WORKER_ADAPTERS
 
     def initialize
       reset
@@ -30,7 +31,6 @@ module Judoscale
       @dyno = ENV["DYNO"]
       @debug = ENV["JUDOSCALE_DEBUG"] == "true"
       @quiet = false
-      @track_long_running_jobs = false
       @max_request_size = 100_000 # ignore request payloads over 100k since they skew the queue times
       @report_interval = 10
       @logger = defined?(Rails) ? Rails.logger : ::Logger.new($stdout)

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -62,7 +62,7 @@ module Judoscale
       end
 
       def track_long_running_jobs?
-        Config.instance.track_long_running_jobs
+        adapter_config.track_long_running_jobs
       end
     end
   end

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -9,7 +9,7 @@ module Judoscale
       include Singleton
 
       def self.adapter_name
-        name.split("::").last
+        @_adapter_name ||= name.split("::").last
       end
 
       attr_writer :queues

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -13,11 +13,15 @@ module Judoscale
         _(config.debug).must_equal false
         _(config.quiet).must_equal false
         _(config.logger).must_equal Rails.logger
-        _(config.max_queues).must_equal 50
         _(config.max_request_size).must_equal 100_000
         _(config.report_interval).must_equal 10
         _(config.track_long_running_jobs).must_equal false
         _(config.worker_adapters).must_equal %i[sidekiq delayed_job que resque]
+
+        config.worker_adapters.each do |adapter_name|
+          adapter_config = config.public_send(adapter_name)
+          _(adapter_config.max_queues).must_equal 50
+        end
       end
     end
 
@@ -46,10 +50,10 @@ module Judoscale
         config.quiet = true
         config.logger = test_logger
         config.track_long_running_jobs = true
-        config.max_queues = 100
         config.max_request_size = 50_000
         config.report_interval = 20
         config.worker_adapters = [:sidekiq, :resque]
+        config.sidekiq.max_queues = 100
       end
 
       config = Config.instance
@@ -58,11 +62,12 @@ module Judoscale
       _(config.debug).must_equal true
       _(config.quiet).must_equal true
       _(config.logger).must_equal test_logger
-      _(config.max_queues).must_equal 100
       _(config.max_request_size).must_equal 50_000
       _(config.report_interval).must_equal 20
       _(config.track_long_running_jobs).must_equal true
       _(config.worker_adapters).must_equal %i[sidekiq resque]
+      _(config.resque.max_queues).must_equal 50
+      _(config.sidekiq.max_queues).must_equal 100
     end
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -15,12 +15,12 @@ module Judoscale
         _(config.logger).must_equal Rails.logger
         _(config.max_request_size).must_equal 100_000
         _(config.report_interval).must_equal 10
-        _(config.track_long_running_jobs).must_equal false
         _(config.worker_adapters).must_equal %i[sidekiq delayed_job que resque]
 
         config.worker_adapters.each do |adapter_name|
           adapter_config = config.public_send(adapter_name)
           _(adapter_config.max_queues).must_equal 50
+          _(adapter_config.track_long_running_jobs).must_equal false
         end
       end
     end
@@ -49,11 +49,11 @@ module Judoscale
         config.debug = true
         config.quiet = true
         config.logger = test_logger
-        config.track_long_running_jobs = true
         config.max_request_size = 50_000
         config.report_interval = 20
         config.worker_adapters = [:sidekiq, :resque]
         config.sidekiq.max_queues = 100
+        config.sidekiq.track_long_running_jobs = true
       end
 
       config = Config.instance
@@ -64,10 +64,11 @@ module Judoscale
       _(config.logger).must_equal test_logger
       _(config.max_request_size).must_equal 50_000
       _(config.report_interval).must_equal 20
-      _(config.track_long_running_jobs).must_equal true
       _(config.worker_adapters).must_equal %i[sidekiq resque]
       _(config.resque.max_queues).must_equal 50
+      _(config.resque.track_long_running_jobs).must_equal false
       _(config.sidekiq.max_queues).must_equal 100
+      _(config.sidekiq.track_long_running_jobs).must_equal true
     end
   end
 end

--- a/test/support/config_helpers.rb
+++ b/test/support/config_helpers.rb
@@ -23,6 +23,22 @@ module ConfigHelpers
     end
   end
 
+  def use_adapter_config(adapter_identifier, options, &example)
+    adapter_config = ::Judoscale::Config.instance.public_send(adapter_identifier)
+    original_config = {}
+
+    options.each do |key, val|
+      original_config[key] = adapter_config.public_send(key)
+      adapter_config.public_send "#{key}=", val
+    end
+
+    example.call
+  ensure
+    options.each do |key, val|
+      adapter_config.public_send "#{key}=", original_config[key]
+    end
+  end
+
   # Reset config instance after each test to ensure changes don't leak to other tests.
   def after_teardown
     Judoscale::Config.instance.reset

--- a/test/support/config_helpers.rb
+++ b/test/support/config_helpers.rb
@@ -9,40 +9,35 @@ module ConfigHelpers
   #     ...
   #   end
   def use_config(options, &example)
-    original_config = {}
-
-    options.each do |key, val|
-      original_config[key] = ::Judoscale::Config.instance.send(key)
-      ::Judoscale::Config.instance.send "#{key}=", val
-    end
-
-    example.call
-  ensure
-    options.each do |key, val|
-      ::Judoscale::Config.instance.send "#{key}=", original_config[key]
-    end
+    swap_config Judoscale::Config.instance, options, example
   end
 
   def use_adapter_config(adapter_identifier, options, &example)
-    adapter_config = ::Judoscale::Config.instance.public_send(adapter_identifier)
-    original_config = {}
-
-    options.each do |key, val|
-      original_config[key] = adapter_config.public_send(key)
-      adapter_config.public_send "#{key}=", val
-    end
-
-    example.call
-  ensure
-    options.each do |key, val|
-      adapter_config.public_send "#{key}=", original_config[key]
-    end
+    adapter_config = Judoscale::Config.instance.public_send(adapter_identifier)
+    swap_config adapter_config, options, example
   end
 
   # Reset config instance after each test to ensure changes don't leak to other tests.
   def after_teardown
     Judoscale::Config.instance.reset
     super
+  end
+
+  private
+
+  def swap_config(config_instance, options, example)
+    original_config = {}
+
+    options.each do |key, val|
+      original_config[key] = config_instance.public_send(key)
+      config_instance.public_send "#{key}=", val
+    end
+
+    example.call
+  ensure
+    options.each do |key, val|
+      config_instance.public_send "#{key}=", original_config[key]
+    end
   end
 end
 

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -95,7 +95,7 @@ module Judoscale
       end
 
       it "tracks long running jobs when the configuration is enabled" do
-        use_config track_long_running_jobs: true do
+        use_adapter_config :delayed_job, track_long_running_jobs: true do
           %w[default default high].each_with_index { |queue, index|
             Delayable.new.delay(queue: queue).perform
             # Create a new worker to simulate "reserving/locking" the next available job for running.
@@ -116,13 +116,15 @@ module Judoscale
       end
 
       it "logs debug information about long running jobs being collected" do
-        use_config debug: true, track_long_running_jobs: true do
-          Delayable.new.delay(queue: "default").perform
-          Delayed::Worker.new.send(:reserve_job)
+        use_config debug: true do
+          use_adapter_config :delayed_job, track_long_running_jobs: true do
+            Delayable.new.delay(queue: "default").perform
+            Delayed::Worker.new.send(:reserve_job)
 
-          subject.collect! store
+            subject.collect! store
 
-          _(log_string).must_match %r{dj-qt.default=.+ dj-busy.default=1}
+            _(log_string).must_match %r{dj-qt.default=.+ dj-busy.default=1}
+          end
         end
       end
 

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -127,7 +127,7 @@ module Judoscale
       end
 
       it "skips metrics collection if exceeding max queues configured limit" do
-        use_config max_queues: 2 do
+        use_adapter_config :delayed_job, max_queues: 2 do
           %w[low default high].each { |queue| Delayable.new.delay(queue: queue).perform }
 
           subject.collect! store

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -53,7 +53,7 @@ module Judoscale
       end
 
       it "skips metrics collection if exceeding max queues configured limit" do
-        use_config max_queues: 2 do
+        use_adapter_config :que, max_queues: 2 do
           %w[low default high].each { |queue| enqueue(queue, Time.now) }
 
           subject.collect! store

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -102,7 +102,7 @@ module Judoscale
       it "skips metrics collection if exceeding max queues configured limit" do
         _(subject).must_be :enabled?
 
-        use_config max_queues: 2 do
+        use_adapter_config :resque, max_queues: 2 do
           queues = %w[low default high]
 
           ::Resque.stub(:queues, queues) {

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -160,7 +160,7 @@ module Judoscale
       it "skips metrics collection if exceeding max queues configured limit" do
         _(subject).must_be :enabled?
 
-        use_config max_queues: 2 do
+        use_adapter_config :sidekiq, max_queues: 2 do
           queues = %w[low default high].map { |name| SidekiqQueueStub.new(name: name) }
 
           ::Sidekiq::Queue.stub(:all, queues) {

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -113,7 +113,7 @@ module Judoscale
       it "tracks long running jobs when the configuration is enabled" do
         _(subject).must_be :enabled?
 
-        use_config track_long_running_jobs: true do
+        use_adapter_config :sidekiq, track_long_running_jobs: true do
           queues = [
             SidekiqQueueStub.new(name: "default", latency: 11, size: 1),
             SidekiqQueueStub.new(name: "high", latency: 22.222222, size: 2)
@@ -143,17 +143,19 @@ module Judoscale
       it "logs debug information about long running jobs being collected" do
         _(subject).must_be :enabled?
 
-        use_config debug: true, track_long_running_jobs: true do
-          queues = [SidekiqQueueStub.new(name: "default", latency: 11, size: 1)]
-          workers = [["pid1", "tid1", {"payload" => {"queue" => "default"}}]]
+        use_config debug: true do
+          use_adapter_config :sidekiq, track_long_running_jobs: true do
+            queues = [SidekiqQueueStub.new(name: "default", latency: 11, size: 1)]
+            workers = [["pid1", "tid1", {"payload" => {"queue" => "default"}}]]
 
-          ::Sidekiq::Workers.stub(:new, workers) {
-            ::Sidekiq::Queue.stub(:all, queues) {
-              subject.collect! store
+            ::Sidekiq::Workers.stub(:new, workers) {
+              ::Sidekiq::Queue.stub(:all, queues) {
+                subject.collect! store
+              }
             }
-          }
 
-          _(log_string).must_match %r{sidekiq-qt.default=.+ sidekiq-qd.default=.+ sidekiq-busy.default=1}
+            _(log_string).must_match %r{sidekiq-qt.default=.+ sidekiq-qd.default=.+ sidekiq-busy.default=1}
+          end
         end
       end
 


### PR DESCRIPTION
This allows each adapter to be configured individually, starting with `max_queues` and `track_long_running_jobs`:

```ruby
Judoscale.configure do |config|
  config.sidekiq.max_queues = 100
  config.sidekiq.track_long_running_jobs = true
end
```

It enables us to introduce more adapter configuration options in the future.