### PR TITLE
Allow specifying a custom proc to filter queues by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
-- Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter ->(queue_name) { %w[low default high].include?(queue_name) }`. By default it will filter out queues matching UUIDs. ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))
+- Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter = ->(queue_name) { /custom/.match?(queue_name) }`. By default it will filter out queues matching UUIDs. ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))
 - Allow per-adapter configuration of `max_queues` and `track_long_running_jobs`, dropping support for the global configurations. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))
 - Drop support for ENV vars `JUDOSCALE_WORKER_ADAPTER`, `JUDOSCALE_LONG_JOBS`, and `JUDOSCALE_MAX_QUEUES`, in favor of using the new block config format. ([#26](https://github.com/judoscale/judoscale-ruby/pull/26))
 - Configure Judoscale through a block: `Judoscale.configure { |config| config.logger = MyLogger.new }`. ([#25](https://github.com/judoscale/judoscale-ruby/pull/25))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter ->(queue_name) { %w[low default high].include?(queue_name) }` ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))
 - Allow per-adapter configuration of `max_queues` and `track_long_running_jobs`, dropping support for the global configurations. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))
 - Drop support for ENV vars `JUDOSCALE_WORKER_ADAPTER`, `JUDOSCALE_LONG_JOBS`, and `JUDOSCALE_MAX_QUEUES`, in favor of using the new block config format. ([#26](https://github.com/judoscale/judoscale-ruby/pull/26))
 - Configure Judoscale through a block: `Judoscale.configure { |config| config.logger = MyLogger.new }`. ([#25](https://github.com/judoscale/judoscale-ruby/pull/25))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
-- Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter ->(queue_name) { %w[low default high].include?(queue_name) }` ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))
+- Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter ->(queue_name) { %w[low default high].include?(queue_name) }`. By default it will filter out queues matching UUIDs. ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))
 - Allow per-adapter configuration of `max_queues` and `track_long_running_jobs`, dropping support for the global configurations. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))
 - Drop support for ENV vars `JUDOSCALE_WORKER_ADAPTER`, `JUDOSCALE_LONG_JOBS`, and `JUDOSCALE_MAX_QUEUES`, in favor of using the new block config format. ([#26](https://github.com/judoscale/judoscale-ruby/pull/26))
 - Configure Judoscale through a block: `Judoscale.configure { |config| config.logger = MyLogger.new }`. ([#25](https://github.com/judoscale/judoscale-ruby/pull/25))

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Judoscale.configure do |config|
   # you'll need to configure this settings for the specific worker adapter or reduce your number of queues.
   config.sidekiq.max_queues = 100
 
+  # Filter queues to collect metrics from with a custom proc.
+  # Return a falsy value (`nil`/`false`) to exclude the queue, any other value will include it.
+  config.sidekiq.queue_filter = ->(queue_name) { %w[low default high].include?(queue_name) }
+
   # Enables reporting for active workers.
   # See [Handling Long-Running Background Jobs](https://judoscale.com/docs/long-running-jobs/) in the Judoscale docs for more.
   config.sidekiq.track_long_running_jobs = true

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Judoscale.configure do |config|
 
   # Filter queues to collect metrics from with a custom proc.
   # Return a falsy value (`nil`/`false`) to exclude the queue, any other value will include it.
-  config.sidekiq.queue_filter = ->(queue_name) { %w[low default high].include?(queue_name) }
+  config.sidekiq.queue_filter = ->(queue_name) { /custom/.match?(queue_name) }
 
   # Enables reporting for active workers.
   # See [Handling Long-Running Background Jobs](https://judoscale.com/docs/long-running-jobs/) in the Judoscale docs for more.

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -7,12 +7,15 @@ module Judoscale
     DEFAULT_WORKER_ADAPTERS = %i[sidekiq delayed_job que resque]
 
     class WorkerAdapterConfig
+      UUID_REGEXP = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
+      DEFAULT_QUEUE_FILTER = ->(queue_name) { !UUID_REGEXP.match?(queue_name) }
+
       attr_accessor :max_queues, :queue_filter, :track_long_running_jobs
 
       def initialize(adapter_name)
         @adapter_name = adapter_name
         @max_queues = 50
-        @queue_filter = nil
+        @queue_filter = DEFAULT_QUEUE_FILTER
         @track_long_running_jobs = false
       end
     end

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -7,11 +7,12 @@ module Judoscale
     DEFAULT_WORKER_ADAPTERS = %i[sidekiq delayed_job que resque]
 
     class WorkerAdapterConfig
-      attr_accessor :max_queues, :track_long_running_jobs
+      attr_accessor :max_queues, :queue_filter, :track_long_running_jobs
 
       def initialize(adapter_name)
         @adapter_name = adapter_name
         @max_queues = 50
+        @queue_filter = nil
         @track_long_running_jobs = false
       end
     end

--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -39,7 +39,8 @@ module Judoscale
           end
         end
 
-        queues_by_name.each do |queue_name, queue|
+        queues.each do |queue_name|
+          queue = queues_by_name[queue_name]
           latency_ms = (queue.latency * 1000).ceil
           depth = queue.size
 

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -128,14 +128,28 @@ module Judoscale
         end
       end
 
-      it "filters queues to collect metrics from based on the configured queue filter proc" do
-        use_adapter_config :delayed_job, queue_filter: ->(queue_name) { queue_name == "low" } do
-          %w[low default high].each { |queue| Delayable.new.delay(queue: queue).perform }
+      it "filters queues matching UUID format by default, to prevent reporting for dynamically generated queues" do
+        %W[low-#{SecureRandom.uuid} default #{SecureRandom.uuid}-high].each { |queue|
+          Delayable.new.delay(queue: queue).perform
+        }
+
+        subject.collect! store
+
+        _(store.measurements.size).must_equal 1
+        _(store.measurements[0].queue_name).must_equal "default"
+      end
+
+      it "filters queues to collect metrics from based on the configured queue filter proc, overriding the default UUID filter" do
+        use_adapter_config :delayed_job, queue_filter: ->(queue_name) { queue_name.start_with? "low" } do
+          %W[low default high low-#{SecureRandom.uuid}].each { |queue|
+            Delayable.new.delay(queue: queue).perform
+          }
 
           subject.collect! store
 
-          _(store.measurements.size).must_equal 1
+          _(store.measurements.size).must_equal 2
           _(store.measurements[0].queue_name).must_equal "low"
+          _(store.measurements[1].queue_name).must_be :start_with?, "low-"
         end
       end
 

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -52,6 +52,17 @@ module Judoscale
         end
       end
 
+      it "filters queues to collect metrics from based on the configured queue filter proc" do
+        use_adapter_config :que, queue_filter: ->(queue_name) { queue_name == "low" } do
+          %w[low default high].each { |queue| enqueue(queue, Time.now) }
+
+          subject.collect! store
+
+          _(store.measurements.size).must_equal 1
+          _(store.measurements[0].queue_name).must_equal "low"
+        end
+      end
+
       it "skips metrics collection if exceeding max queues configured limit" do
         use_adapter_config :que, max_queues: 2 do
           %w[low default high].each { |queue| enqueue(queue, Time.now) }

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -52,14 +52,24 @@ module Judoscale
         end
       end
 
-      it "filters queues to collect metrics from based on the configured queue filter proc" do
-        use_adapter_config :que, queue_filter: ->(queue_name) { queue_name == "low" } do
-          %w[low default high].each { |queue| enqueue(queue, Time.now) }
+      it "filters queues matching UUID format by default, to prevent reporting for dynamically generated queues" do
+        %W[low-#{SecureRandom.uuid} default #{SecureRandom.uuid}-high].each { |queue| enqueue(queue, Time.now) }
+
+        subject.collect! store
+
+        _(store.measurements.size).must_equal 1
+        _(store.measurements[0].queue_name).must_equal "default"
+      end
+
+      it "filters queues to collect metrics from based on the configured queue filter proc, overriding the default UUID filter" do
+        use_adapter_config :que, queue_filter: ->(queue_name) { queue_name.start_with? "low" } do
+          %W[low default high low-#{SecureRandom.uuid}].each { |queue| enqueue(queue, Time.now) }
 
           subject.collect! store
 
-          _(store.measurements.size).must_equal 1
+          _(store.measurements.size).must_equal 2
           _(store.measurements[0].queue_name).must_equal "low"
+          _(store.measurements[1].queue_name).must_be :start_with?, "low-"
         end
       end
 

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -99,11 +99,27 @@ module Judoscale
         end
       end
 
-      it "filters queues to collect metrics from based on the configured queue filter proc" do
+      it "filters queues matching UUID format by default, to prevent reporting for dynamically generated queues" do
         _(subject).must_be :enabled?
 
-        use_adapter_config :resque, queue_filter: ->(queue_name) { queue_name == "low" } do
-          queues = %w[low default high]
+        queues = %W[low-#{SecureRandom.uuid} default #{SecureRandom.uuid}-high]
+        size = 2
+
+        ::Resque.stub(:queues, queues) {
+          ::Resque.stub(:size, size) {
+            subject.collect! store
+          }
+        }
+
+        _(store.measurements.size).must_equal 1
+        _(store.measurements[0].queue_name).must_equal "default"
+      end
+
+      it "filters queues to collect metrics from based on the configured queue filter proc, overriding the default UUID filter" do
+        _(subject).must_be :enabled?
+
+        use_adapter_config :resque, queue_filter: ->(queue_name) { queue_name.start_with? "low" } do
+          queues = %W[low default high low-#{SecureRandom.uuid}]
           size = 2
 
           ::Resque.stub(:queues, queues) {
@@ -112,8 +128,9 @@ module Judoscale
             }
           }
 
-          _(store.measurements.size).must_equal 1
+          _(store.measurements.size).must_equal 2
           _(store.measurements[0].queue_name).must_equal "low"
+          _(store.measurements[1].queue_name).must_be :start_with?, "low-"
         end
       end
 


### PR DESCRIPTION
Specifying a custom proc to filter queues allow for more fine-grained control over which queues should be collected/reported to Judoscale via the config, e.g.:

```ruby
Judoscale.configure do |config|
  config.sidekiq.queue_filter = ->(queue_name) { /custom/.match?(queue_name) }
end
```

By default, any queue matching a UUID is skipped, but setting a new `queue_filter` overrides that default.