### PR TITLE
Report up to max queues instead of skipping reporting altogether, decrease max queues to 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
-- Adapter config `max_queues` to report is now 20 by default. (previously 50) ([#31](https://github.com/judoscale/judoscale-ruby/pull/31))
+- Adapter config `max_queues` to report is now 20 by default (previously 50), and will report up to that number of queues (sorted by queue name length) instead of skipping all the reporting once that threshold is crossed. ([#31](https://github.com/judoscale/judoscale-ruby/pull/31))
 - Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter ->(queue_name) { %w[low default high].include?(queue_name) }`. By default it will filter out queues matching UUIDs. ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))
 - Allow per-adapter configuration of `max_queues` and `track_long_running_jobs`, dropping support for the global configurations. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))
 - Drop support for ENV vars `JUDOSCALE_WORKER_ADAPTER`, `JUDOSCALE_LONG_JOBS`, and `JUDOSCALE_MAX_QUEUES`, in favor of using the new block config format. ([#26](https://github.com/judoscale/judoscale-ruby/pull/26))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Adapter config `max_queues` to report is now 20 by default. (previously 50) ([#31](https://github.com/judoscale/judoscale-ruby/pull/31))
 - Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter ->(queue_name) { %w[low default high].include?(queue_name) }`. By default it will filter out queues matching UUIDs. ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))
 - Allow per-adapter configuration of `max_queues` and `track_long_running_jobs`, dropping support for the global configurations. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))
 - Drop support for ENV vars `JUDOSCALE_WORKER_ADAPTER`, `JUDOSCALE_LONG_JOBS`, and `JUDOSCALE_MAX_QUEUES`, in favor of using the new block config format. ([#26](https://github.com/judoscale/judoscale-ruby/pull/26))

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Each worker adapter have its own set of configurations as well:
 # config/initializers/judoscale.rb
 Judoscale.configure do |config|
   # Worker metrics will only report up to 20 queues by default. If you have more than 20 queues,
-  # you'll need to configure this settings for the specific worker adapter or reduce your number of queues.
+  # you'll need to configure this setting for the specific worker adapter or reduce your number of queues.
   config.sidekiq.max_queues = 30
 
   # Filter queues to collect metrics from with a custom proc.

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Each worker adapter have its own set of configurations as well:
 ```ruby
 # config/initializers/judoscale.rb
 Judoscale.configure do |config|
-  # Worker metrics will only report up to 50 queues by default. If you have more than 50 queues,
+  # Worker metrics will only report up to 20 queues by default. If you have more than 20 queues,
   # you'll need to configure this settings for the specific worker adapter or reduce your number of queues.
-  config.sidekiq.max_queues = 100
+  config.sidekiq.max_queues = 30
 
   # Filter queues to collect metrics from with a custom proc.
   # Return a falsy value (`nil`/`false`) to exclude the queue, any other value will include it.

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -14,7 +14,7 @@ module Judoscale
 
       def initialize(adapter_name)
         @adapter_name = adapter_name
-        @max_queues = 50
+        @max_queues = 20
         @queue_filter = DEFAULT_QUEUE_FILTER
         @track_long_running_jobs = false
       end

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -57,20 +57,23 @@ module Judoscale
           queues = queues.select { |queue| configured_filter.call(queue) }
         end
 
+        queues = filter_max_queues(queues)
+
         Set.new(queues)
       end
 
-      # Don't collect worker metrics if there are unreasonable number of queues.
-      # Should be checked within each worker adapter `collect!` method.
-      def number_of_queues_to_collect_exceeded_limit?(queues_to_collect)
+      # Collect up to the configured `max_queues`, skipping the rest.
+      # We sort queues by name before making the cut-off, as a simple heuristic to keep the shorter ones
+      # and possibly ignore the longer ones, which are more likely to be dynamically generated for example.
+      def filter_max_queues(queues_to_collect)
         queues_size = queues_to_collect.size
         max_queues = adapter_config.max_queues
 
         if queues_size > max_queues
-          logger.warn "Skipping #{self.class.adapter_name} metrics - #{queues_size} queues exceeds the #{max_queues} queue limit"
-          true
+          logger.warn "#{self.class.adapter_name} metrics reporting only #{max_queues} queues max, skipping the rest (#{queues_size - max_queues})"
+          queues_to_collect.sort_by(&:length).first(max_queues)
         else
-          false
+          queues_to_collect
         end
       end
 

--- a/lib/judoscale/worker_adapters/delayed_job.rb
+++ b/lib/judoscale/worker_adapters/delayed_job.rb
@@ -26,9 +26,6 @@ module Judoscale
         SQL
 
         run_at_by_queue = select_rows(sql).to_h
-
-        return if number_of_queues_to_collect_exceeded_limit?(run_at_by_queue)
-
         self.queues |= run_at_by_queue.keys
 
         if track_long_running_jobs?

--- a/lib/judoscale/worker_adapters/que.rb
+++ b/lib/judoscale/worker_adapters/que.rb
@@ -25,9 +25,6 @@ module Judoscale
         SQL
 
         run_at_by_queue = select_rows(sql).to_h
-
-        return if number_of_queues_to_collect_exceeded_limit?(run_at_by_queue)
-
         self.queues |= run_at_by_queue.keys
 
         queues.each do |queue|

--- a/lib/judoscale/worker_adapters/resque.rb
+++ b/lib/judoscale/worker_adapters/resque.rb
@@ -16,9 +16,6 @@ module Judoscale
       def collect!(store)
         log_msg = +""
         current_queues = ::Resque.queues
-
-        return if number_of_queues_to_collect_exceeded_limit?(current_queues)
-
         # Ensure we continue to collect metrics for known queue names, even when nothing is
         # enqueued at the time. Without this, it will appears that the agent is no longer reporting.
         self.queues |= current_queues

--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -23,8 +23,6 @@ module Judoscale
           obj[queue.name] = queue
         end
 
-        return if number_of_queues_to_collect_exceeded_limit?(queues_by_name)
-
         # Ensure we continue to collect metrics for known queue names, even when nothing is
         # enqueued at the time. Without this, it will appear that the agent is no longer reporting.
         queues.each do |queue_name|

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -19,7 +19,7 @@ module Judoscale
 
         config.worker_adapters.each do |adapter_name|
           adapter_config = config.public_send(adapter_name)
-          _(adapter_config.max_queues).must_equal 50
+          _(adapter_config.max_queues).must_equal 20
           _(adapter_config.track_long_running_jobs).must_equal false
         end
       end
@@ -65,7 +65,7 @@ module Judoscale
       _(config.max_request_size).must_equal 50_000
       _(config.report_interval).must_equal 20
       _(config.worker_adapters).must_equal %i[sidekiq resque]
-      _(config.resque.max_queues).must_equal 50
+      _(config.resque.max_queues).must_equal 20
       _(config.resque.track_long_running_jobs).must_equal false
       _(config.sidekiq.max_queues).must_equal 100
       _(config.sidekiq.track_long_running_jobs).must_equal true

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -73,14 +73,16 @@ module Judoscale
         end
       end
 
-      it "skips metrics collection if exceeding max queues configured limit" do
+      it "collects metrics up to the configured number of max queues, sorting by length of the queue name" do
         use_adapter_config :que, max_queues: 2 do
           %w[low default high].each { |queue| enqueue(queue, Time.now) }
 
           subject.collect! store
 
-          _(store.measurements.size).must_equal 0
-          _(log_string).must_match %r{Skipping Que metrics - 3 queues exceeds the 2 queue limit}
+          _(store.measurements.size).must_equal 2
+          _(store.measurements[0].queue_name).must_equal "low"
+          _(store.measurements[1].queue_name).must_equal "high"
+          _(log_string).must_match %r{Que metrics reporting only 2 queues max, skipping the rest \(1\)}
         end
       end
     end

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -134,18 +134,23 @@ module Judoscale
         end
       end
 
-      it "skips metrics collection if exceeding max queues configured limit" do
+      it "collects metrics up to the configured number of max queues, sorting by length of the queue name" do
         _(subject).must_be :enabled?
 
         use_adapter_config :resque, max_queues: 2 do
           queues = %w[low default high]
+          size = 2
 
           ::Resque.stub(:queues, queues) {
-            subject.collect! store
+            ::Resque.stub(:size, size) {
+              subject.collect! store
+            }
           }
 
-          _(store.measurements.size).must_equal 0
-          _(log_string).must_match %r{Skipping Resque metrics - 3 queues exceeds the 2 queue limit}
+          _(store.measurements.size).must_equal 2
+          _(store.measurements[0].queue_name).must_equal "low"
+          _(store.measurements[1].queue_name).must_equal "high"
+          _(log_string).must_match %r{Resque metrics reporting only 2 queues max, skipping the rest \(1\)}
         end
       end
     end


### PR DESCRIPTION
We want to continue sending worker metrics even if the `max_queues` threshold is crossed, so that the dashboard can show the data up to that limit. A warning will be emitted if there are more queues to collect/report that we're skipping as well, and in order to keep the reporting somewhat consistent every time, we are sorting queue names by length. (which has an added benefit of possibly dropping dynamically generated queues which are more likely to have longer names.)