### PR TITLE
Refactor adapter tests: simplify resetting state, remove need for `enabled?` check

### DIFF
--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -36,6 +36,10 @@ module Judoscale
         @queues = filter_queues(new_queues)
       end
 
+      def clear_queues
+        @queues = nil
+      end
+
       def enabled?
         false
       end
@@ -50,7 +54,6 @@ module Judoscale
       end
 
       def filter_queues(queues)
-        return if queues.nil?
         configured_filter = adapter_config.queue_filter
 
         if configured_filter.respond_to?(:call)

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -20,10 +20,8 @@ module Judoscale
     describe "#collect!" do
       let(:store) { Store.instance }
 
-      before {
-        ActiveRecord::Base.connection.execute("DELETE FROM delayed_jobs")
-      }
       after {
+        ActiveRecord::Base.connection.execute("DELETE FROM delayed_jobs")
         subject.clear_queues
         store.clear
       }

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -21,10 +21,12 @@ module Judoscale
       let(:store) { Store.instance }
 
       before {
-        subject.queues = nil
         ActiveRecord::Base.connection.execute("DELETE FROM delayed_jobs")
       }
-      after { store.clear }
+      after {
+        subject.clear_queues
+        store.clear
+      }
 
       it "collects latency for each queue" do
         Delayable.new.delay(queue: "default").perform

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "delayed_job_active_record"
 require "judoscale/worker_adapters/delayed_job"
 require "judoscale/store"
 

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -24,10 +24,12 @@ module Judoscale
       let(:store) { Store.instance }
 
       before {
-        subject.queues = nil
         ActiveRecord::Base.connection.execute("DELETE FROM que_jobs")
       }
-      after { store.clear }
+      after {
+        subject.clear_queues
+        store.clear
+      }
 
       it "collects latency for each queue" do
         enqueue("default", Time.now - 11)

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "que"
 require "judoscale/worker_adapters/que"
 require "judoscale/store"
-require "que"
 
 module Judoscale
   describe WorkerAdapters::Que do

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -23,10 +23,8 @@ module Judoscale
     describe "#collect!" do
       let(:store) { Store.instance }
 
-      before {
-        ActiveRecord::Base.connection.execute("DELETE FROM que_jobs")
-      }
       after {
+        ActiveRecord::Base.connection.execute("DELETE FROM que_jobs")
         subject.clear_queues
         store.clear
       }

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -15,14 +15,17 @@ module Judoscale
     describe "#collect!" do
       let(:store) { Store.instance }
 
+      before {
+        # FIXME: We need to run the `enabled?` check before each test to ensure Resque
+        # gets required, otherwise depending on the tests order some test might fail.
+        _(subject).must_be :enabled?
+      }
       after {
         subject.clear_queues
         store.clear
       }
 
       it "collects latency for each queue" do
-        _(subject).must_be :enabled?
-
         queues = ["default", "high"]
         sizes = {"default" => 1, "high" => 2}
 
@@ -42,8 +45,6 @@ module Judoscale
       end
 
       it "always collects for the default queue" do
-        _(subject).must_be :enabled?
-
         queues = []
         size = 0
 
@@ -60,8 +61,6 @@ module Judoscale
       end
 
       it "always collects for known queues" do
-        _(subject).must_be :enabled?
-
         queues = ["low"]
         size = 0
 
@@ -85,8 +84,6 @@ module Judoscale
       end
 
       it "logs debug information for each queue being collected" do
-        _(subject).must_be :enabled?
-
         use_config debug: true do
           queues = ["default"]
           size = 2
@@ -102,8 +99,6 @@ module Judoscale
       end
 
       it "filters queues matching UUID format by default, to prevent reporting for dynamically generated queues" do
-        _(subject).must_be :enabled?
-
         queues = %W[low-#{SecureRandom.uuid} default #{SecureRandom.uuid}-high]
         size = 2
 
@@ -118,8 +113,6 @@ module Judoscale
       end
 
       it "filters queues to collect metrics from based on the configured queue filter proc, overriding the default UUID filter" do
-        _(subject).must_be :enabled?
-
         use_adapter_config :resque, queue_filter: ->(queue_name) { queue_name.start_with? "low" } do
           queues = %W[low default high low-#{SecureRandom.uuid}]
           size = 2
@@ -137,8 +130,6 @@ module Judoscale
       end
 
       it "collects metrics up to the configured number of max queues, sorting by length of the queue name" do
-        _(subject).must_be :enabled?
-
         use_adapter_config :resque, max_queues: 2 do
           queues = %w[low default high]
           size = 2

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "resque"
 require "judoscale/worker_adapters/resque"
 require "judoscale/store"
 
@@ -15,11 +16,6 @@ module Judoscale
     describe "#collect!" do
       let(:store) { Store.instance }
 
-      before {
-        # FIXME: We need to run the `enabled?` check before each test to ensure Resque
-        # gets required, otherwise depending on the tests order some test might fail.
-        _(subject).must_be :enabled?
-      }
       after {
         subject.clear_queues
         store.clear

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -15,8 +15,10 @@ module Judoscale
     describe "#collect!" do
       let(:store) { Store.instance }
 
-      before { subject.queues = nil }
-      after { store.clear }
+      after {
+        subject.clear_queues
+        store.clear
+      }
 
       it "collects latency for each queue" do
         _(subject).must_be :enabled?

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -17,8 +17,10 @@ module Judoscale
     describe "#collect!" do
       let(:store) { Store.instance }
 
-      before { subject.queues = nil }
-      after { store.clear }
+      after {
+        subject.clear_queues
+        store.clear
+      }
 
       it "collects latency for each queue" do
         _(subject).must_be :enabled?

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "sidekiq/api"
 require "judoscale/worker_adapters/sidekiq"
 require "judoscale/store"
 
@@ -17,11 +18,6 @@ module Judoscale
     describe "#collect!" do
       let(:store) { Store.instance }
 
-      before {
-        # FIXME: We need to run the `enabled?` check before each test to ensure Sidekiq
-        # gets required, otherwise depending on the tests order some test might fail.
-        _(subject).must_be :enabled?
-      }
       after {
         subject.clear_queues
         store.clear


### PR DESCRIPTION
A few quality of life improvements around the adapter tests:

- Remove the need for `enabled?` checks that were there to ensure the proper objects / constants / APIs we needed were available, otherwise random test failures could happen. Require the libraries in their respective test files upfront instead.
- Create an API to clear the queues and avoid setting them as `nil`, simplifying logic and making things a bit more explicit there.
- Use `after` blocks whenever possible to cleanup tests