### PR TITLE
Allow specifying a list of queues to collect metrics from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Allow configuring a list of `queues` to collect metrics from. Any queues not in that list will be excluded. ([#32](https://github.com/judoscale/judoscale-ruby/pull/32))
 - Adapter config `max_queues` to report is now 20 by default (previously 50), and will report up to that number of queues (sorted by queue name length) instead of skipping all the reporting once that threshold is crossed. ([#31](https://github.com/judoscale/judoscale-ruby/pull/31))
 - Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter = ->(queue_name) { /custom/.match?(queue_name) }`. By default it will filter out queues matching UUIDs. ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))
 - Allow per-adapter configuration of `max_queues` and `track_long_running_jobs`, dropping support for the global configurations. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
-- Allow configuring a list of `queues` to collect metrics from. Any queues not in that list will be excluded, and `queue_filter` is not applied. ([#32](https://github.com/judoscale/judoscale-ruby/pull/32))
+- Allow configuring a list of `queues` to collect metrics from. Any queues not in that list will be excluded, and `queue_filter` is not applied. Please note that `max_queues` still applies. ([#33](https://github.com/judoscale/judoscale-ruby/pull/33))
 - Adapter config `max_queues` to report is now 20 by default (previously 50), and will report up to that number of queues (sorted by queue name length) instead of skipping all the reporting once that threshold is crossed. ([#31](https://github.com/judoscale/judoscale-ruby/pull/31))
 - Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter = ->(queue_name) { /custom/.match?(queue_name) }`. By default it will filter out queues matching UUIDs. ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))
 - Allow per-adapter configuration of `max_queues` and `track_long_running_jobs`, dropping support for the global configurations. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
-- Allow configuring a list of `queues` to collect metrics from. Any queues not in that list will be excluded. ([#32](https://github.com/judoscale/judoscale-ruby/pull/32))
+- Allow configuring a list of `queues` to collect metrics from. Any queues not in that list will be excluded, and `queue_filter` is not applied. ([#32](https://github.com/judoscale/judoscale-ruby/pull/32))
 - Adapter config `max_queues` to report is now 20 by default (previously 50), and will report up to that number of queues (sorted by queue name length) instead of skipping all the reporting once that threshold is crossed. ([#31](https://github.com/judoscale/judoscale-ruby/pull/31))
 - Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter = ->(queue_name) { /custom/.match?(queue_name) }`. By default it will filter out queues matching UUIDs. ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))
 - Allow per-adapter configuration of `max_queues` and `track_long_running_jobs`, dropping support for the global configurations. ([#29](https://github.com/judoscale/judoscale-ruby/pull/29))

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Judoscale.configure do |config|
   # you'll need to configure this setting for the specific worker adapter or reduce your number of queues.
   config.sidekiq.max_queues = 30
 
-  # Specify a list of queues to collect metrics from. Anything not listed will be excluded.
+  # Specify a list of queues to collect metrics from. Anything not explicitly listed will be excluded.
+  # When setting the list of queues, `queue_filter` is ignored, but `max_queues` is still respected.
   config.sidekiq.queues = %w[low default high]
 
   # Filter queues to collect metrics from with a custom proc.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Judoscale.configure do |config|
   # you'll need to configure this setting for the specific worker adapter or reduce your number of queues.
   config.sidekiq.max_queues = 30
 
+  # Specify a list of queues to collect metrics from. Anything not listed will be excluded.
+  config.sidekiq.queues = %w[low default high]
+
   # Filter queues to collect metrics from with a custom proc.
   # Return a falsy value (`nil`/`false`) to exclude the queue, any other value will include it.
   config.sidekiq.queue_filter = ->(queue_name) { /custom/.match?(queue_name) }

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -10,11 +10,12 @@ module Judoscale
       UUID_REGEXP = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
       DEFAULT_QUEUE_FILTER = ->(queue_name) { !UUID_REGEXP.match?(queue_name) }
 
-      attr_accessor :max_queues, :queue_filter, :track_long_running_jobs
+      attr_accessor :max_queues, :queues, :queue_filter, :track_long_running_jobs
 
       def initialize(adapter_name)
         @adapter_name = adapter_name
         @max_queues = 20
+        @queues = []
         @queue_filter = DEFAULT_QUEUE_FILTER
         @track_long_running_jobs = false
       end

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -55,13 +55,15 @@ module Judoscale
 
       def filter_queues(queues)
         configured_queues = adapter_config.queues
+
         if configured_queues.empty?
           configured_filter = adapter_config.queue_filter
+
           if configured_filter.respond_to?(:call)
             queues = queues.select { |queue| configured_filter.call(queue) }
           end
         else
-          queues &= configured_queues
+          queues = configured_queues
         end
 
         queues = filter_max_queues(queues)

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -55,11 +55,13 @@ module Judoscale
 
       def filter_queues(queues)
         configured_queues = adapter_config.queues
-        queues &= configured_queues unless configured_queues.empty?
-
-        configured_filter = adapter_config.queue_filter
-        if configured_filter.respond_to?(:call)
-          queues = queues.select { |queue| configured_filter.call(queue) }
+        if configured_queues.empty?
+          configured_filter = adapter_config.queue_filter
+          if configured_filter.respond_to?(:call)
+            queues = queues.select { |queue| configured_filter.call(queue) }
+          end
+        else
+          queues &= configured_queues
         end
 
         queues = filter_max_queues(queues)

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -54,8 +54,10 @@ module Judoscale
       end
 
       def filter_queues(queues)
-        configured_filter = adapter_config.queue_filter
+        configured_queues = adapter_config.queues
+        queues &= configured_queues unless configured_queues.empty?
 
+        configured_filter = adapter_config.queue_filter
         if configured_filter.respond_to?(:call)
           queues = queues.select { |queue| configured_filter.call(queue) }
         end

--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -23,11 +23,6 @@ module Judoscale
           obj[queue.name] = queue
         end
 
-        # Ensure we continue to collect metrics for known queue names, even when nothing is
-        # enqueued at the time. Without this, it will appear that the agent is no longer reporting.
-        queues.each do |queue_name|
-          queues_by_name[queue_name] ||= ::Sidekiq::Queue.new(queue_name)
-        end
         self.queues |= queues_by_name.keys
 
         if track_long_running_jobs?
@@ -38,7 +33,7 @@ module Judoscale
         end
 
         queues.each do |queue_name|
-          queue = queues_by_name[queue_name]
+          queue = queues_by_name.fetch(queue_name) { |name| ::Sidekiq::Queue.new(name) }
           latency_ms = (queue.latency * 1000).ceil
           depth = queue.size
 

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -156,8 +156,8 @@ module Judoscale
         end
       end
 
-      it "collects metrics only from the configured queues if the configuration is present" do
-        use_adapter_config :delayed_job, queues: %w[low] do
+      it "collects metrics only from the configured queues if the configuration is present, ignoring the queue filter" do
+        use_adapter_config :delayed_job, queues: %w[low], queue_filter: ->(queue_name) { queue_name != "low" } do
           %w[low default high].each { |queue| Delayable.new.delay(queue: queue).perform }
 
           subject.collect! store

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -157,13 +157,12 @@ module Judoscale
       end
 
       it "collects metrics only from the configured queues if the configuration is present, ignoring the queue filter" do
-        use_adapter_config :delayed_job, queues: %w[low], queue_filter: ->(queue_name) { queue_name != "low" } do
+        use_adapter_config :delayed_job, queues: %w[low ultra], queue_filter: ->(queue_name) { queue_name != "low" } do
           %w[low default high].each { |queue| Delayable.new.delay(queue: queue).perform }
 
           subject.collect! store
 
-          _(store.measurements.size).must_equal 1
-          _(store.measurements[0].queue_name).must_equal "low"
+          _(store.measurements.map(&:queue_name)).must_equal %w[low ultra]
         end
       end
 
@@ -173,9 +172,7 @@ module Judoscale
 
           subject.collect! store
 
-          _(store.measurements.size).must_equal 2
-          _(store.measurements[0].queue_name).must_equal "low"
-          _(store.measurements[1].queue_name).must_equal "high"
+          _(store.measurements.map(&:queue_name)).must_equal %w[low high]
           _(log_string).must_match %r{DelayedJob metrics reporting only 2 queues max, skipping the rest \(1\)}
         end
       end

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -75,8 +75,8 @@ module Judoscale
         end
       end
 
-      it "collects metrics only from the configured queues if the configuration is present" do
-        use_adapter_config :que, queues: %w[low] do
+      it "collects metrics only from the configured queues if the configuration is present, ignoring the queue filter" do
+        use_adapter_config :que, queues: %w[low], queue_filter: ->(queue_name) { queue_name != "low" } do
           %w[low default high].each { |queue| enqueue(queue, Time.now) }
 
           subject.collect! store

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -38,8 +38,10 @@ module Judoscale
         _(store.measurements.size).must_equal 2
         _(store.measurements[0].queue_name).must_equal "default"
         _(store.measurements[0].value).must_be_within_delta 11000, 5
+        _(store.measurements[0].metric).must_equal :qt
         _(store.measurements[1].queue_name).must_equal "high"
         _(store.measurements[1].value).must_be_within_delta 22222, 5
+        _(store.measurements[1].metric).must_equal :qt
       end
 
       it "logs debug information for each queue being collected" do
@@ -70,6 +72,17 @@ module Judoscale
           _(store.measurements.size).must_equal 2
           _(store.measurements[0].queue_name).must_equal "low"
           _(store.measurements[1].queue_name).must_be :start_with?, "low-"
+        end
+      end
+
+      it "collects metrics only from the configured queues if the configuration is present" do
+        use_adapter_config :que, queues: %w[low] do
+          %w[low default high].each { |queue| enqueue(queue, Time.now) }
+
+          subject.collect! store
+
+          _(store.measurements.size).must_equal 1
+          _(store.measurements[0].queue_name).must_equal "low"
         end
       end
 

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -76,13 +76,12 @@ module Judoscale
       end
 
       it "collects metrics only from the configured queues if the configuration is present, ignoring the queue filter" do
-        use_adapter_config :que, queues: %w[low], queue_filter: ->(queue_name) { queue_name != "low" } do
+        use_adapter_config :que, queues: %w[low ultra], queue_filter: ->(queue_name) { queue_name != "low" } do
           %w[low default high].each { |queue| enqueue(queue, Time.now) }
 
           subject.collect! store
 
-          _(store.measurements.size).must_equal 1
-          _(store.measurements[0].queue_name).must_equal "low"
+          _(store.measurements.map(&:queue_name)).must_equal %w[low ultra]
         end
       end
 
@@ -92,9 +91,7 @@ module Judoscale
 
           subject.collect! store
 
-          _(store.measurements.size).must_equal 2
-          _(store.measurements[0].queue_name).must_equal "low"
-          _(store.measurements[1].queue_name).must_equal "high"
+          _(store.measurements.map(&:queue_name)).must_equal %w[low high]
           _(log_string).must_match %r{Que metrics reporting only 2 queues max, skipping the rest \(1\)}
         end
       end

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -126,7 +126,7 @@ module Judoscale
       end
 
       it "collects metrics only from the configured queues if the configuration is present, ignoring the queue filter" do
-        use_adapter_config :resque, queues: %w[low], queue_filter: ->(queue_name) { queue_name != "low" } do
+        use_adapter_config :resque, queues: %w[low ultra], queue_filter: ->(queue_name) { queue_name != "low" } do
           queues = %w[low default high]
           size = 2
 
@@ -136,8 +136,7 @@ module Judoscale
             }
           }
 
-          _(store.measurements.size).must_equal 1
-          _(store.measurements[0].queue_name).must_equal "low"
+          _(store.measurements.map(&:queue_name)).must_equal %w[low ultra]
         end
       end
 
@@ -152,9 +151,7 @@ module Judoscale
             }
           }
 
-          _(store.measurements.size).must_equal 2
-          _(store.measurements[0].queue_name).must_equal "low"
-          _(store.measurements[1].queue_name).must_equal "high"
+          _(store.measurements.map(&:queue_name)).must_equal %w[low high]
           _(log_string).must_match %r{Resque metrics reporting only 2 queues max, skipping the rest \(1\)}
         end
       end

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -125,6 +125,22 @@ module Judoscale
         end
       end
 
+      it "collects metrics only from the configured queues if the configuration is present" do
+        use_adapter_config :resque, queues: %w[low] do
+          queues = %w[low default high]
+          size = 2
+
+          ::Resque.stub(:queues, queues) {
+            ::Resque.stub(:size, size) {
+              subject.collect! store
+            }
+          }
+
+          _(store.measurements.size).must_equal 1
+          _(store.measurements[0].queue_name).must_equal "low"
+        end
+      end
+
       it "collects metrics up to the configured number of max queues, sorting by length of the queue name" do
         use_adapter_config :resque, max_queues: 2 do
           queues = %w[low default high]

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -125,8 +125,8 @@ module Judoscale
         end
       end
 
-      it "collects metrics only from the configured queues if the configuration is present" do
-        use_adapter_config :resque, queues: %w[low] do
+      it "collects metrics only from the configured queues if the configuration is present, ignoring the queue filter" do
+        use_adapter_config :resque, queues: %w[low], queue_filter: ->(queue_name) { queue_name != "low" } do
           queues = %w[low default high]
           size = 2
 

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -183,16 +183,17 @@ module Judoscale
       end
 
       it "collects metrics only from the configured queues if the configuration is present, ignoring the queue filter" do
-        use_adapter_config :sidekiq, queues: %w[low], queue_filter: ->(queue_name) { queue_name != "low" } do
+        use_adapter_config :sidekiq, queues: %w[low ultra], queue_filter: ->(queue_name) { queue_name != "low" } do
           queues = %w[low default high].map { |name| SidekiqQueueStub.new(name: name, latency: 5, size: 1) }
+          new_queues = {"ultra" => SidekiqQueueStub.new(name: "ultra", latency: 0, size: 0)}
 
           ::Sidekiq::Queue.stub(:all, queues) {
-            subject.collect! store
+            ::Sidekiq::Queue.stub(:new, ->(queue_name) { new_queues.fetch(queue_name) }) {
+              subject.collect! store
+            }
           }
 
-          _(store.measurements.size).must_equal 2
-          _(store.measurements[0].queue_name).must_equal "low"
-          _(store.measurements[1].queue_name).must_equal "low"
+          _(store.measurements.map(&:queue_name)).must_equal %w[low low ultra ultra]
         end
       end
 
@@ -204,11 +205,7 @@ module Judoscale
             subject.collect! store
           }
 
-          _(store.measurements.size).must_equal 4
-          _(store.measurements[0].queue_name).must_equal "low"
-          _(store.measurements[1].queue_name).must_equal "low"
-          _(store.measurements[2].queue_name).must_equal "high"
-          _(store.measurements[3].queue_name).must_equal "high"
+          _(store.measurements.map(&:queue_name)).must_equal %w[low low high high]
           _(log_string).must_match %r{Sidekiq metrics reporting only 2 queues max, skipping the rest \(1\)}
         end
       end

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -182,8 +182,8 @@ module Judoscale
         end
       end
 
-      it "collects metrics only from the configured queues if the configuration is present" do
-        use_adapter_config :sidekiq, queues: %w[low] do
+      it "collects metrics only from the configured queues if the configuration is present, ignoring the queue filter" do
+        use_adapter_config :sidekiq, queues: %w[low], queue_filter: ->(queue_name) { queue_name != "low" } do
           queues = %w[low default high].map { |name| SidekiqQueueStub.new(name: name, latency: 5, size: 1) }
 
           ::Sidekiq::Queue.stub(:all, queues) {


### PR DESCRIPTION
Configuring a list of `queues` tells the adapter to only collect metrics from those queues and ignore any other. The `queue_filter` is also ignored in that case, but the `max_queues` is still respected.

```ruby
Judoscale.configure do |config|
  config.sidekiq.queues = %w[low default high]
end
```