### PR TITLE
Use the cached adapter name to build registration params

### DIFF
--- a/lib/judoscale/registration.rb
+++ b/lib/judoscale/registration.rb
@@ -11,7 +11,7 @@ module Judoscale
         rails_version: defined?(Rails) && Rails.version,
         gem_version: VERSION,
         # example: { worker_adapters: 'Sidekiq,Que' }
-        worker_adapters: worker_adapters.map { |o| o.class.name.split("::").last }.join(",")
+        worker_adapters: worker_adapters.map { |o| o.class.adapter_name }.join(",")
       }
     end
   end


### PR DESCRIPTION
Now that we have each adapter calculate and store its own "name", we can
reuse that to send with the registration instead of re-calculating.