### PR TITLE
Port over changes from Rails Autoscale to silence Adapter AR queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Silence queries from DelayedJob and Que adapters when collecting metrics. ([#35](https://github.com/judoscale/judoscale-ruby/pull/35))
 - Allow configuring a list of `queues` to collect metrics from. Any queues not in that list will be excluded, and `queue_filter` is not applied. Please note that `max_queues` still applies. ([#33](https://github.com/judoscale/judoscale-ruby/pull/33))
 - Adapter config `max_queues` to report is now 20 by default (previously 50), and will report up to that number of queues (sorted by queue name length) instead of skipping all the reporting once that threshold is crossed. ([#31](https://github.com/judoscale/judoscale-ruby/pull/31))
 - Allow configuring a custom proc to filter queues to collect metrics from by name: `queue_filter = ->(queue_name) { /custom/.match?(queue_name) }`. By default it will filter out queues matching UUIDs. ([#30](https://github.com/judoscale/judoscale-ruby/pull/30))

--- a/lib/judoscale/worker_adapters/active_record_helper.rb
+++ b/lib/judoscale/worker_adapters/active_record_helper.rb
@@ -3,6 +3,16 @@ module Judoscale
     module ActiveRecordHelper
       private
 
+      def default_timezone
+        if ::ActiveRecord.respond_to?(:default_timezone)
+          # Rails >= 7
+          ::ActiveRecord.default_timezone
+        else
+          # Rails < 7
+          ::ActiveRecord::Base.default_timezone
+        end
+      end
+
       def select_rows_silently(sql)
         if ::ActiveRecord::Base.logger.respond_to?(:silence)
           ::ActiveRecord::Base.logger.silence { select_rows(sql) }

--- a/lib/judoscale/worker_adapters/active_record_helper.rb
+++ b/lib/judoscale/worker_adapters/active_record_helper.rb
@@ -1,0 +1,20 @@
+module Judoscale
+  module WorkerAdapters
+    module ActiveRecordHelper
+      private
+
+      def select_rows_silently(sql)
+        if ::ActiveRecord::Base.logger.respond_to?(:silence)
+          ::ActiveRecord::Base.logger.silence { select_rows(sql) }
+        else
+          select_rows(sql)
+        end
+      end
+
+      def select_rows(sql)
+        # This ensures the agent doesn't hold onto a DB connection any longer than necessary
+        ActiveRecord::Base.connection_pool.with_connection { |c| c.select_rows(sql) }
+      end
+    end
+  end
+end

--- a/lib/judoscale/worker_adapters/delayed_job.rb
+++ b/lib/judoscale/worker_adapters/delayed_job.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require "judoscale/worker_adapters/base"
+require "judoscale/worker_adapters/active_record_helper"
 
 module Judoscale
   module WorkerAdapters
     class DelayedJob < Base
+      include ActiveRecordHelper
+
       def enabled?
         if defined?(::Delayed::Job) && defined?(::Delayed::Backend::ActiveRecord)
           log_msg = +"DelayedJob enabled (#{::ActiveRecord::Base.default_timezone})"
@@ -60,21 +63,6 @@ module Judoscale
         end
 
         logger.debug log_msg unless log_msg.empty?
-      end
-
-      private
-
-      def select_rows_silently(sql)
-        if ::ActiveRecord::Base.logger.respond_to?(:silence)
-          ::ActiveRecord::Base.logger.silence { select_rows(sql) }
-        else
-          select_rows(sql)
-        end
-      end
-
-      def select_rows(sql)
-        # This ensures the agent doesn't hold onto a DB connection any longer than necessary
-        ActiveRecord::Base.connection_pool.with_connection { |c| c.select_rows(sql) }
       end
     end
   end

--- a/lib/judoscale/worker_adapters/delayed_job.rb
+++ b/lib/judoscale/worker_adapters/delayed_job.rb
@@ -10,7 +10,7 @@ module Judoscale
 
       def enabled?
         if defined?(::Delayed::Job) && defined?(::Delayed::Backend::ActiveRecord)
-          log_msg = +"DelayedJob enabled (#{::ActiveRecord::Base.default_timezone})"
+          log_msg = +"DelayedJob enabled (#{default_timezone})"
           log_msg << " with long-running job support" if track_long_running_jobs?
           logger.info log_msg
           true

--- a/lib/judoscale/worker_adapters/que.rb
+++ b/lib/judoscale/worker_adapters/que.rb
@@ -24,7 +24,7 @@ module Judoscale
           GROUP BY 1
         SQL
 
-        run_at_by_queue = select_rows(sql).to_h
+        run_at_by_queue = select_rows_silently(sql).to_h
         self.queues |= run_at_by_queue.keys
 
         queues.each do |queue|
@@ -41,6 +41,14 @@ module Judoscale
       end
 
       private
+
+      def select_rows_silently(sql)
+        if ::ActiveRecord::Base.logger.respond_to?(:silence)
+          ::ActiveRecord::Base.logger.silence { select_rows(sql) }
+        else
+          select_rows(sql)
+        end
+      end
 
       def select_rows(sql)
         # This ensures the agent doesn't hold onto a DB connection any longer than necessary

--- a/lib/judoscale/worker_adapters/que.rb
+++ b/lib/judoscale/worker_adapters/que.rb
@@ -10,7 +10,7 @@ module Judoscale
 
       def enabled?
         if defined?(::Que)
-          logger.info "Que enabled (#{::ActiveRecord::Base.default_timezone})"
+          logger.info "Que enabled (#{default_timezone})"
           true
         end
       end

--- a/lib/judoscale/worker_adapters/que.rb
+++ b/lib/judoscale/worker_adapters/que.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require "judoscale/worker_adapters/base"
+require "judoscale/worker_adapters/active_record_helper"
 
 module Judoscale
   module WorkerAdapters
     class Que < Base
+      include ActiveRecordHelper
+
       def enabled?
         if defined?(::Que)
           logger.info "Que enabled (#{::ActiveRecord::Base.default_timezone})"
@@ -38,21 +41,6 @@ module Judoscale
         end
 
         logger.debug log_msg unless log_msg.empty?
-      end
-
-      private
-
-      def select_rows_silently(sql)
-        if ::ActiveRecord::Base.logger.respond_to?(:silence)
-          ::ActiveRecord::Base.logger.silence { select_rows(sql) }
-        else
-          select_rows(sql)
-        end
-      end
-
-      def select_rows(sql)
-        # This ensures the agent doesn't hold onto a DB connection any longer than necessary
-        ActiveRecord::Base.connection_pool.with_connection { |c| c.select_rows(sql) }
       end
     end
   end


### PR DESCRIPTION
Ports https://github.com/adamlogic/rails_autoscale_agent/pull/41 and https://github.com/adamlogic/rails_autoscale_agent/pull/44, to silence DelayedJob & Que queries through Active Record if possible.

Extracts AR querying to a shared helper module that can be included in specific adapters that are AR-based, since not all of them are.