### PR TITLE
Rename some configs to better show their intent and/or what value to expect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- `track_long_running_jobs` has been renamed to `track_busy_jobs`. ([#36](https://github.com/judoscale/judoscale-ruby/issues/36))
 - Silence queries from DelayedJob and Que adapters when collecting metrics. ([#35](https://github.com/judoscale/judoscale-ruby/pull/35))
 - Allow configuring a list of `queues` to collect metrics from. Any queues not in that list will be excluded, and `queue_filter` is not applied. Please note that `max_queues` still applies. ([#33](https://github.com/judoscale/judoscale-ruby/pull/33))
 - Adapter config `max_queues` to report is now 20 by default (previously 50), and will report up to that number of queues (sorted by queue name length) instead of skipping all the reporting once that threshold is crossed. ([#31](https://github.com/judoscale/judoscale-ruby/pull/31))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
-- Rename some configs: `<adapter>.track_long_running_jobs` => `<adapter>.track_busy_jobs`; `report_interval` => `report_interval_seconds`. ([#36](https://github.com/judoscale/judoscale-ruby/issues/36))
+- Rename some configs: `<adapter>.track_long_running_jobs` => `<adapter>.track_busy_jobs`, `report_interval` => `report_interval_seconds`, `max_request_size` => `max_request_size_bytes`. ([#36](https://github.com/judoscale/judoscale-ruby/issues/36))
 - Silence queries from DelayedJob and Que adapters when collecting metrics. ([#35](https://github.com/judoscale/judoscale-ruby/pull/35))
 - Allow configuring a list of `queues` to collect metrics from. Any queues not in that list will be excluded, and `queue_filter` is not applied. Please note that `max_queues` still applies. ([#33](https://github.com/judoscale/judoscale-ruby/pull/33))
 - Adapter config `max_queues` to report is now 20 by default (previously 50), and will report up to that number of queues (sorted by queue name length) instead of skipping all the reporting once that threshold is crossed. ([#31](https://github.com/judoscale/judoscale-ruby/pull/31))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
-- `track_long_running_jobs` has been renamed to `track_busy_jobs`. ([#36](https://github.com/judoscale/judoscale-ruby/issues/36))
+- Rename some configs: `<adapter>.track_long_running_jobs` => `<adapter>.track_busy_jobs`; `report_interval` => `report_interval_seconds`. ([#36](https://github.com/judoscale/judoscale-ruby/issues/36))
 - Silence queries from DelayedJob and Que adapters when collecting metrics. ([#35](https://github.com/judoscale/judoscale-ruby/pull/35))
 - Allow configuring a list of `queues` to collect metrics from. Any queues not in that list will be excluded, and `queue_filter` is not applied. Please note that `max_queues` still applies. ([#33](https://github.com/judoscale/judoscale-ruby/pull/33))
 - Adapter config `max_queues` to report is now 20 by default (previously 50), and will report up to that number of queues (sorted by queue name length) instead of skipping all the reporting once that threshold is crossed. ([#31](https://github.com/judoscale/judoscale-ruby/pull/31))

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Judoscale.configure do |config|
 
   # Enables reporting for active workers.
   # See [Handling Long-Running Background Jobs](https://judoscale.com/docs/long-running-jobs/) in the Judoscale docs for more.
-  config.sidekiq.track_long_running_jobs = true
+  config.sidekiq.track_busy_jobs = true
 end
 ```
 

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -23,7 +23,7 @@ module Judoscale
 
     include Singleton
 
-    attr_accessor :report_interval_seconds, :logger, :api_base_url, :max_request_size,
+    attr_accessor :report_interval_seconds, :logger, :api_base_url, :max_request_size_bytes,
       :dyno, :debug, :quiet, :worker_adapters, *DEFAULT_WORKER_ADAPTERS
 
     def initialize
@@ -36,7 +36,7 @@ module Judoscale
       @dyno = ENV["DYNO"]
       @debug = ENV["JUDOSCALE_DEBUG"] == "true"
       @quiet = false
-      @max_request_size = 100_000 # ignore request payloads over 100k since they skew the queue times
+      @max_request_size_bytes = 100_000 # ignore request payloads over 100k since they skew the queue times
       @report_interval_seconds = 10
       @logger = defined?(Rails) ? Rails.logger : ::Logger.new($stdout)
       @worker_adapters = DEFAULT_WORKER_ADAPTERS
@@ -51,7 +51,7 @@ module Judoscale
     end
 
     def ignore_large_requests?
-      @max_request_size
+      @max_request_size_bytes
     end
 
     alias_method :debug?, :debug

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -23,7 +23,7 @@ module Judoscale
 
     include Singleton
 
-    attr_accessor :report_interval, :logger, :api_base_url, :max_request_size,
+    attr_accessor :report_interval_seconds, :logger, :api_base_url, :max_request_size,
       :dyno, :debug, :quiet, :worker_adapters, *DEFAULT_WORKER_ADAPTERS
 
     def initialize
@@ -37,7 +37,7 @@ module Judoscale
       @debug = ENV["JUDOSCALE_DEBUG"] == "true"
       @quiet = false
       @max_request_size = 100_000 # ignore request payloads over 100k since they skew the queue times
-      @report_interval = 10
+      @report_interval_seconds = 10
       @logger = defined?(Rails) ? Rails.logger : ::Logger.new($stdout)
       @worker_adapters = DEFAULT_WORKER_ADAPTERS
 

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -10,14 +10,14 @@ module Judoscale
       UUID_REGEXP = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
       DEFAULT_QUEUE_FILTER = ->(queue_name) { !UUID_REGEXP.match?(queue_name) }
 
-      attr_accessor :max_queues, :queues, :queue_filter, :track_long_running_jobs
+      attr_accessor :max_queues, :queues, :queue_filter, :track_busy_jobs
 
       def initialize(adapter_name)
         @adapter_name = adapter_name
         @max_queues = 20
         @queues = []
         @queue_filter = DEFAULT_QUEUE_FILTER
-        @track_long_running_jobs = false
+        @track_busy_jobs = false
       end
     end
 

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -31,7 +31,7 @@ module Judoscale
 
           # Stagger reporting to spread out reports from many processes
           multiplier = 1 - (rand / 4) # between 0.75 and 1.0
-          sleep config.report_interval * multiplier
+          sleep config.report_interval_seconds * multiplier
 
           # It's redundant to report worker metrics from every web dyno, so only report from web.1
           if dyno_num == 1
@@ -86,7 +86,7 @@ module Judoscale
       when AutoscaleApi::SuccessResponse
         @registered = true
         worker_adapters_msg = worker_adapters.map { |a| a.class.name }.join(", ")
-        logger.info "Reporter starting, will report every #{config.report_interval} seconds or so. Worker adapters: [#{worker_adapters_msg}]"
+        logger.info "Reporter starting, will report every #{config.report_interval_seconds} seconds or so. Worker adapters: [#{worker_adapters_msg}]"
       when AutoscaleApi::FailureResponse
         logger.error "Reporter failed to register: #{result.failure_message}"
       end

--- a/lib/judoscale/request.rb
+++ b/lib/judoscale/request.rb
@@ -13,7 +13,7 @@ module Judoscale
     end
 
     def ignore?
-      @config.ignore_large_requests? && @size > @config.max_request_size
+      @config.ignore_large_requests? && @size > @config.max_request_size_bytes
     end
 
     def started_at

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -86,8 +86,8 @@ module Judoscale
         end
       end
 
-      def track_long_running_jobs?
-        adapter_config.track_long_running_jobs
+      def track_busy_jobs?
+        adapter_config.track_busy_jobs
       end
     end
   end

--- a/lib/judoscale/worker_adapters/sidekiq.rb
+++ b/lib/judoscale/worker_adapters/sidekiq.rb
@@ -9,7 +9,7 @@ module Judoscale
         require "sidekiq/api"
 
         log_msg = +"Sidekiq enabled"
-        log_msg << " with long-running job support" if track_long_running_jobs?
+        log_msg << " with busy job tracking support" if track_busy_jobs?
         logger.info log_msg
 
         true
@@ -25,7 +25,7 @@ module Judoscale
 
         self.queues |= queues_by_name.keys
 
-        if track_long_running_jobs?
+        if track_busy_jobs?
           busy_counts = Hash.new { |h, k| h[k] = 0 }
           ::Sidekiq::Workers.new.each do |pid, tid, work|
             busy_counts[work.dig("payload", "queue")] += 1
@@ -41,7 +41,7 @@ module Judoscale
           store.push :qd, depth, Time.now, queue_name
           log_msg << "sidekiq-qt.#{queue_name}=#{latency_ms}ms sidekiq-qd.#{queue_name}=#{depth} "
 
-          if track_long_running_jobs?
+          if track_busy_jobs?
             busy_count = busy_counts[queue_name]
             store.push :busy, busy_count, Time.now, queue_name
             log_msg << "sidekiq-busy.#{queue_name}=#{busy_count} "

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -14,7 +14,7 @@ module Judoscale
         _(config.quiet).must_equal false
         _(config.logger).must_equal Rails.logger
         _(config.max_request_size).must_equal 100_000
-        _(config.report_interval).must_equal 10
+        _(config.report_interval_seconds).must_equal 10
         _(config.worker_adapters).must_equal %i[sidekiq delayed_job que resque]
 
         config.worker_adapters.each do |adapter_name|
@@ -50,7 +50,7 @@ module Judoscale
         config.quiet = true
         config.logger = test_logger
         config.max_request_size = 50_000
-        config.report_interval = 20
+        config.report_interval_seconds = 20
         config.worker_adapters = [:sidekiq, :resque]
         config.sidekiq.max_queues = 100
         config.sidekiq.track_busy_jobs = true
@@ -63,7 +63,7 @@ module Judoscale
       _(config.quiet).must_equal true
       _(config.logger).must_equal test_logger
       _(config.max_request_size).must_equal 50_000
-      _(config.report_interval).must_equal 20
+      _(config.report_interval_seconds).must_equal 20
       _(config.worker_adapters).must_equal %i[sidekiq resque]
       _(config.resque.max_queues).must_equal 20
       _(config.resque.track_busy_jobs).must_equal false

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -13,7 +13,7 @@ module Judoscale
         _(config.debug).must_equal false
         _(config.quiet).must_equal false
         _(config.logger).must_equal Rails.logger
-        _(config.max_request_size).must_equal 100_000
+        _(config.max_request_size_bytes).must_equal 100_000
         _(config.report_interval_seconds).must_equal 10
         _(config.worker_adapters).must_equal %i[sidekiq delayed_job que resque]
 
@@ -49,7 +49,7 @@ module Judoscale
         config.debug = true
         config.quiet = true
         config.logger = test_logger
-        config.max_request_size = 50_000
+        config.max_request_size_bytes = 50_000
         config.report_interval_seconds = 20
         config.worker_adapters = [:sidekiq, :resque]
         config.sidekiq.max_queues = 100
@@ -62,7 +62,7 @@ module Judoscale
       _(config.debug).must_equal true
       _(config.quiet).must_equal true
       _(config.logger).must_equal test_logger
-      _(config.max_request_size).must_equal 50_000
+      _(config.max_request_size_bytes).must_equal 50_000
       _(config.report_interval_seconds).must_equal 20
       _(config.worker_adapters).must_equal %i[sidekiq resque]
       _(config.resque.max_queues).must_equal 20

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -20,7 +20,7 @@ module Judoscale
         config.worker_adapters.each do |adapter_name|
           adapter_config = config.public_send(adapter_name)
           _(adapter_config.max_queues).must_equal 20
-          _(adapter_config.track_long_running_jobs).must_equal false
+          _(adapter_config.track_busy_jobs).must_equal false
         end
       end
     end
@@ -53,7 +53,7 @@ module Judoscale
         config.report_interval = 20
         config.worker_adapters = [:sidekiq, :resque]
         config.sidekiq.max_queues = 100
-        config.sidekiq.track_long_running_jobs = true
+        config.sidekiq.track_busy_jobs = true
       end
 
       config = Config.instance
@@ -66,9 +66,9 @@ module Judoscale
       _(config.report_interval).must_equal 20
       _(config.worker_adapters).must_equal %i[sidekiq resque]
       _(config.resque.max_queues).must_equal 20
-      _(config.resque.track_long_running_jobs).must_equal false
+      _(config.resque.track_busy_jobs).must_equal false
       _(config.sidekiq.max_queues).must_equal 100
-      _(config.sidekiq.track_long_running_jobs).must_equal true
+      _(config.sidekiq.track_busy_jobs).must_equal true
     end
   end
 end

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -98,7 +98,7 @@ module Judoscale
       end
 
       it "tracks long running jobs when the configuration is enabled" do
-        use_adapter_config :delayed_job, track_long_running_jobs: true do
+        use_adapter_config :delayed_job, track_busy_jobs: true do
           %w[default default high].each_with_index { |queue, index|
             Delayable.new.delay(queue: queue).perform
             # Create a new worker to simulate "reserving/locking" the next available job for running.
@@ -120,7 +120,7 @@ module Judoscale
 
       it "logs debug information about long running jobs being collected" do
         use_config debug: true do
-          use_adapter_config :delayed_job, track_long_running_jobs: true do
+          use_adapter_config :delayed_job, track_busy_jobs: true do
             Delayable.new.delay(queue: "default").perform
             Delayed::Worker.new.send(:reserve_job)
 

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -106,7 +106,7 @@ module Judoscale
       end
 
       it "tracks long running jobs when the configuration is enabled" do
-        use_adapter_config :sidekiq, track_long_running_jobs: true do
+        use_adapter_config :sidekiq, track_busy_jobs: true do
           queues = [
             SidekiqQueueStub.new(name: "default", latency: 11, size: 1),
             SidekiqQueueStub.new(name: "high", latency: 22.222222, size: 2)
@@ -135,7 +135,7 @@ module Judoscale
 
       it "logs debug information about long running jobs being collected" do
         use_config debug: true do
-          use_adapter_config :sidekiq, track_long_running_jobs: true do
+          use_adapter_config :sidekiq, track_busy_jobs: true do
             queues = [SidekiqQueueStub.new(name: "default", latency: 11, size: 1)]
             workers = [["pid1", "tid1", {"payload" => {"queue" => "default"}}]]
 


### PR DESCRIPTION
- `<adapter>.track_long_running_jobs` => `<adapter>.track_busy_jobs`
- `report_interval` => `report_interval_seconds`
- `max_request_size` => `max_request_size_bytes`