### PR TITLE
Combine `debug` and `quiet` configs into a single `log_level`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Combine `debug` and `quiet` config options into a single `log_level` which controls how our logging should behave. ([#37](https://github.com/judoscale/judoscale-ruby/issues/37))
 - Rename some configs: `<adapter>.track_long_running_jobs` => `<adapter>.track_busy_jobs`, `report_interval` => `report_interval_seconds`, `max_request_size` => `max_request_size_bytes`. ([#36](https://github.com/judoscale/judoscale-ruby/issues/36))
 - Silence queries from DelayedJob and Que adapters when collecting metrics. ([#35](https://github.com/judoscale/judoscale-ruby/pull/35))
 - Allow configuring a list of `queues` to collect metrics from. Any queues not in that list will be excluded, and `queue_filter` is not applied. Please note that `max_queues` still applies. ([#33](https://github.com/judoscale/judoscale-ruby/pull/33))

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Most Judoscale configurations are handled via the settings page on your Judoscal
 Judoscale.configure do |config|
   # configure Judoscale here, more on each configuration option below.
 
-  # Enables debug logging. This can also be enabled/disabled via the JUDOSCALE_DEBUG environment variable.
+  # Enables debug logging. This can also be enabled/disabled by setting `JUDOSCALE_LOG_LEVEL=debug`.
   # See more in the [logging](#logging) section below.
-  config.debug = true
+  config.log_level = :debug
 
   # Overrides the available worker adapters. See more in the [worker adapters](#worker-adapters) section below.
   config.worker_adapters = %i[sidekiq resque]
@@ -111,14 +111,14 @@ Once installed, you should see something like this in your development log:
 
 In production, run `heroku logs -t | grep Judoscale`, and you should see something like this:
 
-> [Judoscale] Reporter starting, will report every 15 seconds
+> [Judoscale] Reporter starting, will report every 10 seconds
 
 If you don't see either of these, try running `bundle` again and restarting your Rails application.
 
-You can see more detailed (debug) logging by setting `JUDOSCALE_DEBUG` on your Heroku app:
+You can see more detailed (debug) logging by setting `JUDOSCALE_LOG_LEVEL` on your Heroku app:
 
 ```
-heroku config:add JUDOSCALE_DEBUG=true
+heroku config:set JUDOSCALE_LOG_LEVEL=debug
 ```
 
 See more in the [logging](#logging) section below.
@@ -127,7 +127,7 @@ Reach out to help@judoscale.com if you run into any other problems.
 
 ## Logging
 
-The Rails logger is used by default.
+The Rails logger is used by default when present, otherwise Judoscale will log everything to `stdout`.
 If you wish to use a different logger you can set it on the configuration object:
 
 ```ruby
@@ -137,20 +137,43 @@ Judoscale.configure do |config|
 end
 ```
 
-Debug logs are silenced by default because Rails apps default to a DEBUG log level in production, and this gem has _very_ chatty debug logs. If you want to see the debug logs, set `JUDOSCALE_DEBUG` on your Heroku app:
+The logger controls the log level by default. In case of Rails apps, that's going to be defined by the `log_level` config in each environment, so if your app is set to log at INFO level, you will only see Judoscale INFO logs as well. Please note that this gem has _very_ chatty debug logs, so if your app is set to DEBUG you will also see a lot of Judoscale debug logging output, which looks like this:
 
 ```
-heroku config:set JUDOSCALE_DEBUG=true
+[Judoscale] [DEBUG] Some debug log message
 ```
 
-If you find the gem too chatty even without this, you can quiet it down further:
+If you find the gem too chatty with that setup, you can quiet it down further with a more strict log level that only affects Judoscale logging:
 
 ```ruby
 # config/initializers/judoscale.rb
 Judoscale.configure do |config|
-  config.quiet = true
+  config.log_level = :info
 end
 ```
+
+Alternatively, set the `JUDOSCALE_LOG_LEVEL` environment variable on your Heroku app:
+
+```
+heroku config:set JUDOSCALE_LOG_LEVEL=info
+```
+
+If you want the debug logs even if your app is not using the DEBUG level, set either the `log_level` config:
+
+```ruby
+# config/initializers/judoscale.rb
+Judoscale.configure do |config|
+  config.log_level = :debug
+end
+```
+
+Or `JUDOSCALE_LOG_LEVEL` on your app:
+
+```
+heroku config:set JUDOSCALE_LOG_LEVEL=debug
+```
+
+Enabling the debug level will start logging everything, independently of the underlying logger level. It's recommended to enable it temporarily if you need to [troubleshoot](#troubleshooting) any issues.
 
 ## Development
 

--- a/lib/judoscale/worker_adapters/active_record_helper.rb
+++ b/lib/judoscale/worker_adapters/active_record_helper.rb
@@ -14,8 +14,8 @@ module Judoscale
       end
 
       def select_rows_silently(sql)
-        if ::ActiveRecord::Base.logger.respond_to?(:silence)
-          ::ActiveRecord::Base.logger.silence { select_rows(sql) }
+        if Config.instance.log_level && ::ActiveRecord::Base.logger.respond_to?(:silence)
+          ::ActiveRecord::Base.logger.silence(Config.instance.log_level) { select_rows(sql) }
         else
           select_rows(sql)
         end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -10,8 +10,7 @@ module Judoscale
         config = Config.instance
         _(config.api_base_url).must_equal "https://example.com"
         _(config.dyno).must_equal "web.1"
-        _(config.debug).must_equal false
-        _(config.quiet).must_equal false
+        _(config.log_level).must_be_nil
         _(config.logger).must_equal Rails.logger
         _(config.max_request_size_bytes).must_equal 100_000
         _(config.report_interval_seconds).must_equal 10
@@ -29,14 +28,14 @@ module Judoscale
       env = {
         "DYNO" => "web.2",
         "JUDOSCALE_URL" => "https://custom.example.com",
-        "JUDOSCALE_DEBUG" => "true"
+        "JUDOSCALE_LOG_LEVEL" => "debug"
       }
 
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://custom.example.com"
         _(config.dyno).must_equal "web.2"
-        _(config.debug).must_equal true
+        _(config.log_level).must_equal ::Logger::Severity::DEBUG
       end
     end
 
@@ -46,8 +45,7 @@ module Judoscale
       Judoscale.configure do |config|
         config.dyno = "web.3"
         config.api_base_url = "https://block.example.com"
-        config.debug = true
-        config.quiet = true
+        config.log_level = :info
         config.logger = test_logger
         config.max_request_size_bytes = 50_000
         config.report_interval_seconds = 20
@@ -59,8 +57,7 @@ module Judoscale
       config = Config.instance
       _(config.api_base_url).must_equal "https://block.example.com"
       _(config.dyno).must_equal "web.3"
-      _(config.debug).must_equal true
-      _(config.quiet).must_equal true
+      _(config.log_level).must_equal ::Logger::Severity::INFO
       _(config.logger).must_equal test_logger
       _(config.max_request_size_bytes).must_equal 50_000
       _(config.report_interval_seconds).must_equal 20

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -69,7 +69,7 @@ module Judoscale
           end
 
           it "logs debug information about the request and queue time" do
-            use_config debug: true do
+            use_config log_level: :debug do
               env["HTTP_X_REQUEST_ID"] = "req-abc-123"
 
               middleware.call(env)

--- a/test/worker_adapters/delayed_job_test.rb
+++ b/test/worker_adapters/delayed_job_test.rb
@@ -87,7 +87,7 @@ module Judoscale
       end
 
       it "logs debug information for each queue being collected" do
-        use_config debug: true do
+        use_config log_level: :debug do
           Delayable.new.delay(queue: "default").perform
 
           subject.collect! store
@@ -119,7 +119,7 @@ module Judoscale
       end
 
       it "logs debug information about long running jobs being collected" do
-        use_config debug: true do
+        use_config log_level: :debug do
           use_adapter_config :delayed_job, track_busy_jobs: true do
             Delayable.new.delay(queue: "default").perform
             Delayed::Worker.new.send(:reserve_job)

--- a/test/worker_adapters/que_test.rb
+++ b/test/worker_adapters/que_test.rb
@@ -45,7 +45,7 @@ module Judoscale
       end
 
       it "logs debug information for each queue being collected" do
-        use_config debug: true do
+        use_config log_level: :debug do
           enqueue("default", Time.now)
 
           subject.collect! store

--- a/test/worker_adapters/resque_test.rb
+++ b/test/worker_adapters/resque_test.rb
@@ -80,7 +80,7 @@ module Judoscale
       end
 
       it "logs debug information for each queue being collected" do
-        use_config debug: true do
+        use_config log_level: :debug do
           queues = ["default"]
           size = 2
 

--- a/test/worker_adapters/sidekiq_test.rb
+++ b/test/worker_adapters/sidekiq_test.rb
@@ -93,7 +93,7 @@ module Judoscale
       end
 
       it "logs debug information for each queue being collected" do
-        use_config debug: true do
+        use_config log_level: :debug do
           queues = [SidekiqQueueStub.new(name: "default", latency: 11, size: 1)]
 
           ::Sidekiq::Queue.stub(:all, queues) {
@@ -134,7 +134,7 @@ module Judoscale
       end
 
       it "logs debug information about long running jobs being collected" do
-        use_config debug: true do
+        use_config log_level: :debug do
           use_adapter_config :sidekiq, track_busy_jobs: true do
             queues = [SidekiqQueueStub.new(name: "default", latency: 11, size: 1)]
             workers = [["pid1", "tid1", {"payload" => {"queue" => "default"}}]]


### PR DESCRIPTION
This allows us to simplify the logging implementation via a
configuration to control the log level. Our logging wraps the underlying
logger (i.e. Rails.logger) and only passes down messages that have a
matching severity, dropping lower severity messages on the floor.

If the `log_level` isn't set, we simply pass everything down and allow
the underlying logger to handle the proper log level.

The `debug` level is treated a bit differently though, as we want to be
able to let clients enable `debug` temporarily, even if their apps are
setup with a higher level like `info`. In that case, we log at the
logger level instead of our configured level, to ensure it gets logged,
and prefix all messages with an extra `[DEBUG]` tag, to make them easier
to identify and search for.