### PR TITLE
Allow disabling/enabling each adapter individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Drop `worker_adapters` config list in favor of setting it for each individual adapter `<adapter>.enabled = true|false`. This allows to manually disable reporting for any automatically enabled adapter. ([#38](https://github.com/judoscale/judoscale-ruby/issues/38))
 - Combine `debug` and `quiet` config options into a single `log_level` which controls how our logging should behave. ([#37](https://github.com/judoscale/judoscale-ruby/issues/37))
 - Rename some configs: `<adapter>.track_long_running_jobs` => `<adapter>.track_busy_jobs`, `report_interval` => `report_interval_seconds`, `max_request_size` => `max_request_size_bytes`. ([#36](https://github.com/judoscale/judoscale-ruby/issues/36))
 - Silence queries from DelayedJob and Que adapters when collecting metrics. ([#35](https://github.com/judoscale/judoscale-ruby/pull/35))

--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ Judoscale.configure do |config|
   # Enables debug logging. This can also be enabled/disabled by setting `JUDOSCALE_LOG_LEVEL=debug`.
   # See more in the [logging](#logging) section below.
   config.log_level = :debug
-
-  # Overrides the available worker adapters. See more in the [worker adapters](#worker-adapters) section below.
-  config.worker_adapters = %i[sidekiq resque]
 end
 ```
 
@@ -65,7 +62,7 @@ In some scenarios you might want to override this behavior. Let's say you have b
 ```ruby
 # config/initializers/judoscale.rb
 Judoscale.configure do |config|
-  config.worker_adapters = [:sidekiq]
+  config.resque.enabled = false
 end
 ```
 
@@ -74,7 +71,8 @@ You can also disable collection of worker metrics altogether:
 ```ruby
 # config/initializers/judoscale.rb
 Judoscale.configure do |config|
-  config.worker_adapters = []
+  config.resque.enabled = false
+  config.sidekiq.enabled = false
 end
 ```
 

--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -11,10 +11,11 @@ module Judoscale
       UUID_REGEXP = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
       DEFAULT_QUEUE_FILTER = ->(queue_name) { !UUID_REGEXP.match?(queue_name) }
 
-      attr_accessor :max_queues, :queues, :queue_filter, :track_busy_jobs
+      attr_accessor :enabled, :max_queues, :queues, :queue_filter, :track_busy_jobs
 
       def initialize(adapter_name)
         @adapter_name = adapter_name
+        @enabled = true
         @max_queues = 20
         @queues = []
         @queue_filter = DEFAULT_QUEUE_FILTER
@@ -25,7 +26,7 @@ module Judoscale
     include Singleton
 
     attr_accessor :api_base_url, :dyno, :report_interval_seconds, :max_request_size_bytes,
-      :logger, :worker_adapters, *DEFAULT_WORKER_ADAPTERS
+      :logger, *DEFAULT_WORKER_ADAPTERS
     attr_reader :log_level
 
     def initialize
@@ -57,6 +58,12 @@ module Judoscale
 
     def ignore_large_requests?
       @max_request_size_bytes
+    end
+
+    def worker_adapters
+      DEFAULT_WORKER_ADAPTERS.select { |adapter|
+        instance_variable_get(:"@#{adapter}").enabled
+      }
     end
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -18,6 +18,7 @@ module Judoscale
 
         config.worker_adapters.each do |adapter_name|
           adapter_config = config.public_send(adapter_name)
+          _(adapter_config.enabled).must_equal true
           _(adapter_config.max_queues).must_equal 20
           _(adapter_config.track_busy_jobs).must_equal false
         end
@@ -49,9 +50,10 @@ module Judoscale
         config.logger = test_logger
         config.max_request_size_bytes = 50_000
         config.report_interval_seconds = 20
-        config.worker_adapters = [:sidekiq, :resque]
         config.sidekiq.max_queues = 100
         config.sidekiq.track_busy_jobs = true
+        config.delayed_job.enabled = false
+        config.que.enabled = false
       end
 
       config = Config.instance
@@ -62,10 +64,14 @@ module Judoscale
       _(config.max_request_size_bytes).must_equal 50_000
       _(config.report_interval_seconds).must_equal 20
       _(config.worker_adapters).must_equal %i[sidekiq resque]
+      _(config.resque.enabled).must_equal true
       _(config.resque.max_queues).must_equal 20
       _(config.resque.track_busy_jobs).must_equal false
+      _(config.sidekiq.enabled).must_equal true
       _(config.sidekiq.max_queues).must_equal 100
       _(config.sidekiq.track_busy_jobs).must_equal true
+      _(config.delayed_job.enabled).must_equal false
+      _(config.que.enabled).must_equal false
     end
   end
 end


### PR DESCRIPTION
Instead of setting a list of adapters based on symbol identifiers, use
the config for each adapter to set a new `enabled` flag, which
essentially allows clients to disable an adapter if they need.