### PR TITLE
Refactor the metrics store: introduce the "flush" concept, decouple from the report

### DIFF
--- a/lib/judoscale/metrics_store.rb
+++ b/lib/judoscale/metrics_store.rb
@@ -8,29 +8,38 @@ module Judoscale
   class MetricsStore
     include Singleton
 
-    attr_reader :metrics
+    attr_reader :metrics, :flushed_at
 
     def initialize
       @metrics = []
-      @last_pop = Time.now
+      @flushed_at = Time.now
     end
 
     def push(identifier, value, time = Time.now, queue_name = nil)
       # If it's been two minutes since clearing out the store, stop collecting metrics.
       # There could be an issue with the reporter, and continuing to collect will consume linear memory.
-      return if @last_pop && @last_pop < Time.now - 120
+      return if @flushed_at && @flushed_at < Time.now - 120
 
       @metrics << Metric.new(identifier, time, value, queue_name)
     end
 
-    def pop_report
-      @last_pop = Time.now
-      report = Report.new
+    def flush
+      @flushed_at = Time.now
+      flushed_metrics = []
 
       while (metric = @metrics.shift)
-        report.metrics << metric
+        flushed_metrics << metric
       end
 
+      flushed_metrics
+    end
+
+    # TODO: This is going to be left untouched temporarily while we refactor how the reporting happens.
+    def pop_report
+      flushed_metrics = flush
+
+      report = Report.new
+      report.metrics.concat(flushed_metrics)
       report
     end
 

--- a/lib/judoscale/metrics_store.rb
+++ b/lib/judoscale/metrics_store.rb
@@ -34,15 +34,6 @@ module Judoscale
       flushed_metrics
     end
 
-    # TODO: This is going to be left untouched temporarily while we refactor how the reporting happens.
-    def pop_report
-      flushed_metrics = flush
-
-      report = Report.new
-      report.metrics.concat(flushed_metrics)
-      report
-    end
-
     def clear
       @metrics.clear
     end

--- a/lib/judoscale/report.rb
+++ b/lib/judoscale/report.rb
@@ -4,8 +4,8 @@ module Judoscale
   class Report
     attr_reader :metrics
 
-    def initialize
-      @metrics = []
+    def initialize(metrics = [])
+      @metrics = metrics
     end
 
     def to_params(config)

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -63,7 +63,7 @@ module Judoscale
     private
 
     def report!(config, store)
-      report = store.pop_report
+      report = Report.new(store.flush)
 
       logger.info "Reporting #{report.metrics.size} metrics"
 

--- a/test/metrics_store_test.rb
+++ b/test/metrics_store_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "judoscale/metrics_store"
+
+module Judoscale
+  describe MetricsStore do
+    let(:store) { MetricsStore.instance }
+
+    after { store.clear }
+
+    describe "#push" do
+      it "keeps tracking of the pushed metrics internally in memory for reporting at a later time" do
+        _(store.metrics).must_be :empty?
+
+        store.push :qt, 1, Time.now
+
+        _(store.metrics.size).must_equal 1
+        _(store.metrics.first.identifier).must_equal :qt
+      end
+
+      it "stops tracking metrics after 2 minutes, assuming there was an issue with reporting, to avoid memory growing indefinitely" do
+        store.push :qt, 1, Time.now
+        _(store.metrics.size).must_equal 1
+
+        Time.stub(:now, Time.now + 121) do
+          store.push :qt, 1, Time.now
+        end
+        _(store.metrics.size).must_equal 1
+      end
+    end
+
+    describe "#flush" do
+      it "returns all metrics currently tracked by the store, clearing them in the process" do
+        1.upto(3) { |i| store.push :qt, i, Time.now }
+        _(store.metrics.size).must_equal 3
+
+        flushed_metrics = store.flush
+        _(flushed_metrics.size).must_equal 3
+        _(store.metrics).must_be :empty?
+      end
+
+      it "tracks the last time metrics were flushed for reporting to allow continuously pushing metrics to the store" do
+        flushed_at = store.flushed_at
+
+        _(store.flush).must_be :empty?
+        _(store.flushed_at).wont_equal flushed_at
+
+        second_flushed_at = store.flushed_at
+        store.push :qt, 1, Time.now
+
+        _(store.flush.size).must_equal 1
+        _(store.flushed_at).wont_equal second_flushed_at
+      end
+    end
+  end
+end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -54,11 +54,11 @@ module Judoscale
           it "collects the request queue time" do
             middleware.call(env)
 
-            report = MetricsStore.instance.pop_report
-            _(report.metrics.length).must_equal 1
-            _(report.metrics.first).must_be_instance_of Metric
-            _(report.metrics.first.value).must_be_within_delta 5000, 1
-            _(report.metrics.first.identifier).must_equal :qt
+            metrics = MetricsStore.instance.flush
+            _(metrics.length).must_equal 1
+            _(metrics.first).must_be_instance_of Metric
+            _(metrics.first.value).must_be_within_delta 5000, 1
+            _(metrics.first.identifier).must_equal :qt
           end
 
           it "records the queue time in the environment passed on" do
@@ -84,8 +84,8 @@ module Judoscale
             it "does not collect the request queue time" do
               middleware.call(env)
 
-              report = MetricsStore.instance.pop_report
-              _(report.metrics.length).must_equal 0
+              metrics = MetricsStore.instance.flush
+              _(metrics.length).must_equal 0
             end
           end
 
@@ -95,11 +95,11 @@ module Judoscale
             it "collects the request network time as a separate metric" do
               middleware.call(env)
 
-              report = MetricsStore.instance.pop_report
-              _(report.metrics.length).must_equal 2
-              _(report.metrics.last).must_be_instance_of Metric
-              _(report.metrics.last.value).must_be_within_delta 50, 1
-              _(report.metrics.last.identifier).must_equal :nt
+              metrics = MetricsStore.instance.flush
+              _(metrics.length).must_equal 2
+              _(metrics.last).must_be_instance_of Metric
+              _(metrics.last.value).must_be_within_delta 50, 1
+              _(metrics.last.identifier).must_equal :nt
             end
 
             it "records the network time in the environment passed on" do


### PR DESCRIPTION
This allows the metrics store to only be concerned about keeping track of metrics internally, and "flushing" them when the reporter is ready to submit things to the API, but not knowing about the existence of an intermediate "report" object.

The reporter is now responsible for flushing the cache and building a new "report" with the collected metrics, to send everything to the API.