### PR TITLE
Move the report metrics API to use JSON instead of CSV

### DIFF
--- a/lib/judoscale/adapter_api.rb
+++ b/lib/judoscale/adapter_api.rb
@@ -15,9 +15,8 @@ module Judoscale
       @config = config
     end
 
-    def report_metrics!(report_params, timings_csv)
-      query = URI.encode_www_form(report_params)
-      post_csv "/adapter/v1/metrics?#{query}", timings_csv
+    def report_metrics!(report_params)
+      post_json "/adapter/v1/metrics", report_params
     end
 
     def register_reporter!(registration_params)
@@ -29,11 +28,6 @@ module Judoscale
     def post_json(path, data)
       headers = {"Content-Type" => "application/json"}
       post_raw path: path, body: JSON.dump(data), headers: headers
-    end
-
-    def post_csv(path, data)
-      headers = {"Content-Type" => "text/csv"}
-      post_raw path: path, body: data, headers: headers
     end
 
     def post_raw(options)

--- a/lib/judoscale/report.rb
+++ b/lib/judoscale/report.rb
@@ -2,32 +2,25 @@
 
 module Judoscale
   class Report
-    attr_reader :metrics
+    attr_reader :config, :metrics
 
-    def initialize(metrics = [])
+    def initialize(config, metrics = [])
+      @config = config
       @metrics = metrics
     end
 
-    def to_params(config)
+    def to_params
       {
         dyno: config.dyno,
-        pid: Process.pid
-      }
-    end
-
-    def to_csv
-      (+"").tap do |result|
-        @metrics.each do |metric|
-          result << [
+        metrics: metrics.map do |metric|
+          [
             metric.time.to_i,
             metric.value,
-            metric.queue_name,
-            metric.identifier
-          ].join(",")
-
-          result << "\n"
+            metric.identifier,
+            metric.queue_name
+          ]
         end
-      end
+      }
     end
   end
 end

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -63,12 +63,9 @@ module Judoscale
     private
 
     def report!(config, store)
-      report = Report.new(store.flush)
-
+      report = Report.new(config, store.flush)
       logger.info "Reporting #{report.metrics.size} metrics"
-
-      params = report.to_params(config)
-      result = AdapterApi.new(config).report_metrics!(params, report.to_csv)
+      result = AdapterApi.new(config).report_metrics!(report.to_params)
 
       case result
       when AdapterApi::SuccessResponse

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -65,10 +65,8 @@ module Judoscale
       it "reports stored metrics to the API" do
         store = MetricsStore.instance
 
-        expected_query = {dyno: "web.1", pid: Process.pid}
-        expected_body = "1000000001,11,,qt\n1000000002,22,high,qt\n"
-        stub = stub_request(:post, "http://example.com/api/test-token/adapter/v1/metrics")
-          .with(query: expected_query, body: expected_body)
+        expected_body = {dyno: "web.1", metrics: [[1000000001, 11, "qt", nil], [1000000002, 22, "qt", "high"]]}
+        stub = stub_request(:post, "http://example.com/api/test-token/adapter/v1/metrics").with(body: expected_body)
 
         store.push :qt, 11, Time.at(1_000_000_001) # web metric
         store.push :qt, 22, Time.at(1_000_000_002), "high" # worker metric

--- a/test/vcr_cassettes/Judoscale_AdapterApi/_report_metrics_/returns_a_failure_response_if_the_service_is_unavailable.yml
+++ b/test/vcr_cassettes/Judoscale_AdapterApi/_report_metrics_/returns_a_failure_response_if_the_service_is_unavailable.yml
@@ -5,9 +5,7 @@ http_interactions:
     uri: http://does-not-exist.dev/adapter/v1/metrics
     body:
       encoding: UTF-8
-      string: |
-        1498939883,11
-        1498939883,33
+      string: '{"dyno":"web.1","metrics":[[1645534290,11,"qt"],[1645534290,33,"qt"]]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/test/vcr_cassettes/Judoscale_AdapterApi/_report_metrics_/returns_a_failure_response_if_we_post_unexpected_params.yml
+++ b/test/vcr_cassettes/Judoscale_AdapterApi/_report_metrics_/returns_a_failure_response_if_we_post_unexpected_params.yml
@@ -5,9 +5,7 @@ http_interactions:
     uri: http://judoscale.dev/api/bad-app-token/adapter/v1/metrics
     body:
       encoding: UTF-8
-      string: |
-        1498939882,11
-        1498939882,33
+      string: '{"dyno":"web.1","metrics":[[1645534290,11,"qt"],[1645534290,33,"qt"]]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/test/vcr_cassettes/Judoscale_AdapterApi/_report_metrics_/returns_a_successful_response.yml
+++ b/test/vcr_cassettes/Judoscale_AdapterApi/_report_metrics_/returns_a_successful_response.yml
@@ -2,12 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: http://judoscale.dev/api/test-app-token/adapter/v1/metrics?dyno=web.1&pid=1232
+    uri: http://judoscale.dev/api/test-app-token/adapter/v1/metrics
     body:
       encoding: UTF-8
-      string: |
-        1498939882,11
-        1498939882,33
+      string: '{"dyno":"web.1","metrics":[[1645534290,11,"qt"],[1645534290,33,"qt"]]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/test/vcr_cassettes/Judoscale_AdapterApi/_report_metrics_/supports_HTTPS.yml
+++ b/test/vcr_cassettes/Judoscale_AdapterApi/_report_metrics_/supports_HTTPS.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://judoscale-production.herokuapp.com/api/test-token/adapter/v1/metrics?dyno=web.1&pid=1232
+    uri: https://judoscale-production.herokuapp.com/api/test-token/adapter/v1/metrics
     body:
       encoding: UTF-8
       string: 'does not matter'


### PR DESCRIPTION
This simplifies the reporting API and makes it more consistent with the
registration by always using JSON to talk to the API.

The API used a combination of query params for some attributes, and a
CSV body. This merges the whole payload into a single JSON body. We are
now only sending the `dyno` and dropping the `pid`, as that has not been
very useful information.

We still build the metrics as a list of arrays instead of JSON objects
to keep the reporting simpler and the payload smaller, which makes it
still very similar to a CSV from the looks of it, but it's just one
piece of the JSON payload, and enables us to extend it further in the
future.