### PR TITLE
Rename methods to identify them as returning "json-like" hashes

### DIFF
--- a/lib/judoscale/adapter_api.rb
+++ b/lib/judoscale/adapter_api.rb
@@ -15,12 +15,12 @@ module Judoscale
       @config = config
     end
 
-    def report_metrics!(report_params)
-      post_json "/adapter/v1/metrics", report_params
+    def report_metrics!(report_json)
+      post_json "/adapter/v1/metrics", report_json
     end
 
-    def register_reporter!(registration_params)
-      post_json "/adapter/v1/registrations", registration: registration_params
+    def register_reporter!(registration_json)
+      post_json "/adapter/v1/registrations", registration: registration_json
     end
 
     private

--- a/lib/judoscale/registration.rb
+++ b/lib/judoscale/registration.rb
@@ -4,7 +4,7 @@ require "judoscale/version"
 
 module Judoscale
   class Registration < Struct.new(:worker_adapters)
-    def to_params
+    def as_json
       {
         pid: Process.pid,
         ruby_version: RUBY_VERSION,

--- a/lib/judoscale/report.rb
+++ b/lib/judoscale/report.rb
@@ -9,7 +9,7 @@ module Judoscale
       @metrics = metrics
     end
 
-    def to_params
+    def as_json
       {
         dyno: config.dyno,
         metrics: metrics.map do |metric|

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -65,7 +65,7 @@ module Judoscale
     def report!(config, store)
       report = Report.new(config, store.flush)
       logger.info "Reporting #{report.metrics.size} metrics"
-      result = AdapterApi.new(config).report_metrics!(report.to_params)
+      result = AdapterApi.new(config).report_metrics!(report.as_json)
 
       case result
       when AdapterApi::SuccessResponse
@@ -76,8 +76,8 @@ module Judoscale
     end
 
     def register!(config, worker_adapters)
-      params = Registration.new(worker_adapters).to_params
-      result = AdapterApi.new(config).register_reporter!(params)
+      registration = Registration.new(worker_adapters)
+      result = AdapterApi.new(config).register_reporter!(registration.as_json)
 
       case result
       when AdapterApi::SuccessResponse


### PR DESCRIPTION
`to_params` seemed too generic when what we really want is to use this
to dump a hash of data to be sent via the JSON API, `as_json` seems to
represent that better.

Ref: https://github.com/judoscale/judoscale-ruby/pull/42#discussion_r811974066