### PR TITLE
Rename Middleware => RequestMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The agent will only communicate with Judoscale if a `JUDOSCALE_URL` ENV variable
 
 ## Non-Rails Rack apps
 
-You'll need to `require 'judoscale/middleware'` and insert the `Judoscale::Middleware` manually. Insert it before `Rack::Runtime` to ensure accuracy of request queue timings.
+You'll need to `require 'judoscale/request_middleware'` and insert the `Judoscale::RequestMiddleware` manually. Insert it before `Rack::Runtime` to ensure accuracy of request queue timings.
 
 ## What data is collected?
 

--- a/lib/judoscale/railtie.rb
+++ b/lib/judoscale/railtie.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require "judoscale/middleware"
+require "judoscale/request_middleware"
 require "judoscale/logger"
 
 module Judoscale
   class Railtie < Rails::Railtie
     include Logger
 
-    initializer "judoscale.middleware" do |app|
-      logger.info "Preparing middleware"
-      app.middleware.insert_before Rack::Runtime, Middleware
+    initializer "judoscale.request_middleware" do |app|
+      logger.info "Preparing request middleware"
+      app.middleware.insert_before Rack::Runtime, RequestMiddleware
     end
   end
 end

--- a/lib/judoscale/request_middleware.rb
+++ b/lib/judoscale/request_middleware.rb
@@ -7,7 +7,7 @@ require "judoscale/logger"
 require "judoscale/request_metrics"
 
 module Judoscale
-  class Middleware
+  class RequestMiddleware
     include Logger
 
     def initialize(app)

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "judoscale/middleware"
+require "judoscale/request_middleware"
 
 module Judoscale
   class MockApp
@@ -13,7 +13,7 @@ module Judoscale
     end
   end
 
-  describe Middleware do
+  describe RequestMiddleware do
     describe "#call" do
       after {
         Reporter.instance.stop!
@@ -28,7 +28,7 @@ module Judoscale
           "rack.input" => StringIO.new("hello")
         }
       }
-      let(:middleware) { Middleware.new(app) }
+      let(:middleware) { RequestMiddleware.new(app) }
 
       describe "with the API URL configured" do
         before {


### PR DESCRIPTION
Better identify its usage. I forgot to rename this one with https://github.com/judoscale/judoscale-ruby/pull/39.