### PR TITLE
Implement the collectors interface for the reporter

### DIFF
--- a/lib/judoscale/config.rb
+++ b/lib/judoscale/config.rb
@@ -56,6 +56,10 @@ module Judoscale
       "#{@dyno}##{Process.pid}"
     end
 
+    def dyno_num
+      dyno.to_s.split(".").last.to_i
+    end
+
     def ignore_large_requests?
       @max_request_size_bytes
     end

--- a/lib/judoscale/job_metrics_collector.rb
+++ b/lib/judoscale/job_metrics_collector.rb
@@ -10,7 +10,7 @@ module Judoscale
     def collect
       store = []
       worker_adapter.collect!(store)
-      store.map! { |args| Metric.new(*args) }
+      store.map! { |(identifier, value, time, queue_name)| Metric.new(identifier, time, value, name) }
       store
     end
   end

--- a/lib/judoscale/job_metrics_collector.rb
+++ b/lib/judoscale/job_metrics_collector.rb
@@ -1,0 +1,17 @@
+module Judoscale
+  class JobMetricsCollector
+    # TODO: the worker adapters will be refactored into job collectors, for now this allows us to
+    # wrap that implementation temporarily to aid the refactoring and build the interfaces we want.
+    def initialize(worker_adapter)
+      @worker_adapter = worker_adapter
+      super()
+    end
+
+    def collect
+      store = []
+      worker_adapter.collect!(store)
+      store.map! { |args| Metric.new(*args) }
+      store
+    end
+  end
+end

--- a/lib/judoscale/job_metrics_collector.rb
+++ b/lib/judoscale/job_metrics_collector.rb
@@ -1,10 +1,22 @@
+# frozen_string_literal: true
+
+require "judoscale/metrics_collector"
+
 module Judoscale
-  class JobMetricsCollector
+  class JobMetricsCollector < MetricsCollector
+    attr_reader :worker_adapter
+
     # TODO: the worker adapters will be refactored into job collectors, for now this allows us to
     # wrap that implementation temporarily to aid the refactoring and build the interfaces we want.
     def initialize(worker_adapter)
       @worker_adapter = worker_adapter
       super()
+    end
+
+    # Override the collector name to delegate to the worker adapter, so we can log "Sidekiq"
+    # (for example) instead of "Job".
+    def collector_name
+      worker_adapter.class.adapter_name
     end
 
     def collect

--- a/lib/judoscale/job_metrics_collector.rb
+++ b/lib/judoscale/job_metrics_collector.rb
@@ -4,6 +4,18 @@ require "judoscale/metrics_collector"
 
 module Judoscale
   class JobMetricsCollector < MetricsCollector
+    class TempStore
+      attr_reader :metrics
+
+      def initialize
+        @metrics = []
+      end
+
+      def push(identifier, value, time, queue_name)
+        @metrics << Metric.new(identifier, time, value, queue_name)
+      end
+    end
+
     attr_reader :worker_adapter
 
     # TODO: the worker adapters will be refactored into job collectors, for now this allows us to
@@ -20,10 +32,9 @@ module Judoscale
     end
 
     def collect
-      store = []
+      store = TempStore.new
       worker_adapter.collect!(store)
-      store.map! { |(identifier, value, time, queue_name)| Metric.new(identifier, time, value, name) }
-      store
+      store.metrics
     end
   end
 end

--- a/lib/judoscale/metrics_collector.rb
+++ b/lib/judoscale/metrics_collector.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Judoscale
+  class MetricsCollector
+    # Collector class name extracted from the full class name.
+    # Example: Judoscale::MyCustomMetricsCollector.collector_name => 'MyCustom'
+    def self.collector_name
+      @_collector_name ||= name.split("::").last.sub(/MetricsCollector$/, "")
+    end
+
+    def collector_name
+      self.class.collector_name
+    end
+
+    def collect
+      []
+    end
+  end
+end

--- a/lib/judoscale/registration.rb
+++ b/lib/judoscale/registration.rb
@@ -3,15 +3,15 @@
 require "judoscale/version"
 
 module Judoscale
-  class Registration < Struct.new(:worker_adapters)
+  class Registration < Struct.new(:collectors)
     def as_json
       {
         pid: Process.pid,
         ruby_version: RUBY_VERSION,
         rails_version: defined?(Rails) && Rails.version,
         gem_version: VERSION,
-        # example: { worker_adapters: 'Sidekiq,Que' }
-        worker_adapters: worker_adapters.map { |o| o.class.adapter_name }.join(",")
+        # example: { collectors: 'Web,Sidekiq' }
+        collectors: collectors.map(&:collector_name).join(",")
       }
     end
   end

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -18,7 +18,7 @@ module Judoscale
     def start!(config, store)
       @started = true
       worker_adapters = WorkerAdapters.load_adapters(config.worker_adapters).select(&:enabled?)
-      dyno_num = config.dyno.to_s.split(".").last.to_i
+      dyno_num = config.dyno_num
 
       if !config.api_base_url
         logger.info "Reporter not started: JUDOSCALE_URL is not set"

--- a/lib/judoscale/reporter.rb
+++ b/lib/judoscale/reporter.rb
@@ -4,6 +4,7 @@ require "singleton"
 require "judoscale/logger"
 require "judoscale/adapter_api"
 require "judoscale/registration"
+require "judoscale/job_metrics_collector"
 require "judoscale/web_metrics_collector"
 require "judoscale/worker_adapters"
 
@@ -18,7 +19,11 @@ module Judoscale
 
         collectors = [WebMetricsCollector.new]
         # It's redundant to report worker metrics from every web dyno, so only report from web.1
-        collectors.concat(worker_adapters) if config.dyno_num == 1
+        if config.dyno_num == 1
+          worker_adapters.each do |worker_adapter|
+            collectors.push JobMetricsCollector.new(worker_adapter)
+          end
+        end
 
         instance.start!(config, worker_adapters, collectors)
       end

--- a/lib/judoscale/request_middleware.rb
+++ b/lib/judoscale/request_middleware.rb
@@ -23,10 +23,11 @@ module Judoscale
         network_time = request_metrics.network_time
       end
 
-      store = MetricsStore.instance
-      Reporter.start(config, store)
+      Reporter.start(config)
 
       if queue_time
+        store = MetricsStore.instance
+
         # NOTE: Expose queue time to the app
         env["judoscale.queue_time"] = queue_time
         store.push :qt, queue_time

--- a/lib/judoscale/web_metrics_collector.rb
+++ b/lib/judoscale/web_metrics_collector.rb
@@ -1,0 +1,9 @@
+require "judoscale/metrics_store"
+
+module Judoscale
+  class WebMetricsCollector
+    def collect
+      MetricsStore.instance.flush
+    end
+  end
+end

--- a/lib/judoscale/web_metrics_collector.rb
+++ b/lib/judoscale/web_metrics_collector.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
+require "judoscale/metrics_collector"
 require "judoscale/metrics_store"
 
 module Judoscale
-  class WebMetricsCollector
+  class WebMetricsCollector < MetricsCollector
     def collect
       MetricsStore.instance.flush
     end

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -44,13 +44,6 @@ module Judoscale
         false
       end
 
-      def collect
-        store = []
-        collect!(store)
-        store.map! { |args| Metric.new(*args) }
-        store
-      end
-
       def collect!(store)
       end
 

--- a/lib/judoscale/worker_adapters/base.rb
+++ b/lib/judoscale/worker_adapters/base.rb
@@ -44,6 +44,13 @@ module Judoscale
         false
       end
 
+      def collect
+        store = []
+        collect!(store)
+        store.map! { |args| Metric.new(*args) }
+        store
+      end
+
       def collect!(store)
       end
 

--- a/test/job_metrics_collector_test.rb
+++ b/test/job_metrics_collector_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "judoscale/job_metrics_collector"
+
+module Judoscale
+  class JobTestWorkerAdapter
+    def collect!(store)
+      1.upto(3) { |i| store.push :qt, i, Time.now, "some-queue" }
+    end
+  end
+
+  describe JobMetricsCollector do
+    describe "#collect" do
+      it "wraps a worker adapter to collect metrics from" do
+        collector = JobMetricsCollector.new(JobTestWorkerAdapter.new)
+        collected_metrics = collector.collect
+
+        _(collected_metrics.size).must_equal 3
+        _(collected_metrics.map(&:value)).must_equal [1, 2, 3]
+        _(collected_metrics[0].identifier).must_equal :qt
+        _(collected_metrics[0].queue_name).must_equal "some-queue"
+      end
+    end
+  end
+end

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -5,7 +5,7 @@ require "judoscale/reporter"
 require "judoscale/config"
 
 module Judoscale
-  class TestCollector
+  class TestMetricsCollector < MetricsCollector
     def collect
     end
   end
@@ -28,7 +28,7 @@ module Judoscale
 
       def run_reporter_start_thread(collectors: [])
         stub_reporter_loop {
-          reporter_thread = Reporter.instance.start!(Config.instance, [], collectors)
+          reporter_thread = Reporter.instance.start!(Config.instance, collectors)
           reporter_thread.join
         }
       end
@@ -51,10 +51,10 @@ module Judoscale
       end
 
       it "logs exceptions when collecting information" do
-        collector = TestCollector.new
+        metrics_collector = TestMetricsCollector.new
 
-        collector.stub(:collect, ->(*) { raise "ADAPTER BOOM!" }) {
-          run_reporter_start_thread(collectors: [collector])
+        metrics_collector.stub(:collect, ->(*) { raise "ADAPTER BOOM!" }) {
+          run_reporter_start_thread(collectors: [metrics_collector])
         }
 
         _(log_string).must_include "Reporter error: #<RuntimeError: ADAPTER BOOM!>"
@@ -102,7 +102,7 @@ module Judoscale
             ruby_version: RUBY_VERSION,
             rails_version: "5.0.fake",
             gem_version: Judoscale::VERSION,
-            worker_adapters: ""
+            collectors: ""
           }
         }
         response = {}.to_json

--- a/test/web_metrics_collector_test.rb
+++ b/test/web_metrics_collector_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "judoscale/web_metrics_collector"
+
+module Judoscale
+  describe WebMetricsCollector do
+    let(:store) { MetricsStore.instance }
+
+    describe "#collect" do
+      it "flushes the metrics previously collected from the store" do
+        collector = WebMetricsCollector.new
+        _(collector.collect).must_be :empty?
+
+        1.upto(3) { |i| store.push :qt, i, Time.now }
+        _(store.metrics.size).must_equal 3
+
+        collected_metrics = collector.collect
+
+        _(collected_metrics.size).must_equal 3
+        _(collected_metrics.map(&:value)).must_equal [1, 2, 3]
+        _(collected_metrics[0].identifier).must_equal :qt
+        _(store.metrics).must_be :empty?
+      end
+    end
+  end
+end


### PR DESCRIPTION

Move away from the reporter keeping track of worker adapters & store flushing concepts, to wrap these into a "metrics collector" interface that each of the web & job implementations will use, so that the reporter can be simplified to just collecting those metrics and reporting them.

In the web scenario, the metrics are still coming from the MetricsStore, that's receiving metrics for each web request.

In case of jobs, however, the "store" concept is really ephemeral and only needs to exist for the duration of the metrics collection, as we don't need to keep these metrics anywhere else for any time longer than that. So we'll simply collect metrics and return them right away, without the usage of a "store".

For now, the "job metrics collector" implementation is just a wrapper around the worker adapters, so we can implement this new interface without reorganizing them, but in a future change we want to move each of the worker adapter to be one "metrics collector" of its own instead.

__