### PR TITLE
Cleanup: Remove unused `.rspec` file and `log` folder

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---format documentation
---color


### PR DESCRIPTION
We moved to minitest so this `.rspec` config file is no longer needed,
and I missed it before.

We've also reworked the logging to use `StringIO` so no need to keep a
log folder anymore.