### PR TITLE
Reorder arguments to build Metric objects

### DIFF
--- a/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
@@ -12,7 +12,7 @@ module Judoscale
       end
 
       def push(identifier, value, time, queue_name)
-        @metrics << Metric.new(identifier, time, value, queue_name)
+        @metrics << Metric.new(identifier, value, time, queue_name)
       end
     end
 

--- a/judoscale-ruby/lib/judoscale/metric.rb
+++ b/judoscale-ruby/lib/judoscale/metric.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Judoscale
-  class Metric < Struct.new(:identifier, :time, :value, :queue_name)
+  class Metric < Struct.new(:identifier, :value, :time, :queue_name)
     # No queue_name is assumed to be a web request metric
     # Metrics: qt = queue time (default), qd = queue depth, busy
-    def initialize(identifier, time, value, queue_name = nil)
-      super identifier, time.utc, value.to_i, queue_name
+    def initialize(identifier, value, time, queue_name = nil)
+      super identifier, value.to_i, time.utc, queue_name
     end
   end
 end

--- a/judoscale-ruby/lib/judoscale/metrics_store.rb
+++ b/judoscale-ruby/lib/judoscale/metrics_store.rb
@@ -20,7 +20,7 @@ module Judoscale
       # There could be an issue with the reporter, and continuing to collect will consume linear memory.
       return if @flushed_at && @flushed_at < Time.now - 120
 
-      @metrics << Metric.new(identifier, time, value, queue_name)
+      @metrics << Metric.new(identifier, value, time, queue_name)
     end
 
     def flush

--- a/judoscale-ruby/test/metric_test.rb
+++ b/judoscale-ruby/test/metric_test.rb
@@ -8,14 +8,14 @@ module Judoscale
   describe Metric do
     describe "#value" do
       it "is always an Integer" do
-        metric = Metric.new(:qt, Time.now, 123.45)
+        metric = Metric.new(:qt, 123.45, Time.now)
         _(metric.value).must_equal 123
       end
     end
 
     describe "#time" do
       it "is always in UTC" do
-        metric = Metric.new(:qt, Time.iso8601("2016-12-03T01:11:00-05:00"), 123)
+        metric = Metric.new(:qt, 123, Time.iso8601("2016-12-03T01:11:00-05:00"))
         _(metric.time.iso8601).must_equal "2016-12-03T06:11:00Z"
       end
     end

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -111,8 +111,8 @@ module Judoscale
         stub = stub_request(:post, "http://example.com/api/test-token/adapter/v1/metrics").with(body: expected_body)
 
         metrics = [
-          Metric.new(:qt, Time.at(1_000_000_001), 11), # web metric
-          Metric.new(:qt, Time.at(1_000_000_002), 22, "high") # worker metric
+          Metric.new(:qt, 11, Time.at(1_000_000_001)), # web metric
+          Metric.new(:qt, 22, Time.at(1_000_000_002), "high") # worker metric
         ]
 
         Reporter.instance.send :report!, Config.instance, metrics
@@ -124,7 +124,7 @@ module Judoscale
         stub_request(:post, %r{http://example.com/api/test-token/adapter/v1/metrics})
           .to_return(body: "oops", status: 503)
 
-        metrics = [Metric.new(:qt, Time.at(1_000_000_001), 1)] # need some metric to trigger reporting
+        metrics = [Metric.new(:qt, 1, Time.at(1_000_000_001))] # need some metric to trigger reporting
 
         log_io = StringIO.new
         stub_logger = ::Logger.new(log_io)


### PR DESCRIPTION
We push metrics arguments to the store with value / time, but build the
actual Metric objects that we store with these arguments reversed, i.e.
time / value. This changes the order of the Metric arguments to keep the
Store & Metric more consistent. It is mostly an internal change that
shouldn't affect callers / users of the code in general.

I want to use the Metric object from the new job metrics collectors (to build the collected metrics list) and I hit test errors due to the arg orders that bugged me a bit, so I thought we could reorder them for consistency.