### PR TITLE
Start reporter with the Rails app 

### DIFF
--- a/judoscale-rails/lib/judoscale/rails/railtie.rb
+++ b/judoscale-rails/lib/judoscale/rails/railtie.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require "rails"
 require "rails/railtie"
 require "judoscale/request_middleware"
 require "judoscale/config"
 require "judoscale/logger"
+require "judoscale/reporter"
 
 module Judoscale
   module Rails
@@ -17,6 +19,10 @@ module Judoscale
       initializer "judoscale.request_middleware" do |app|
         logger.info "Preparing request middleware"
         app.middleware.insert_before Rack::Runtime, RequestMiddleware
+      end
+
+      config.after_initialize do
+        Reporter.start(Config.instance)
       end
     end
   end

--- a/judoscale-rails/test/app_test.rb
+++ b/judoscale-rails/test/app_test.rb
@@ -11,7 +11,6 @@ module Judoscale
     end
 
     after {
-      Reporter.instance.stop!
       MetricsStore.instance.clear
     }
 

--- a/judoscale-rails/test/railtie_test.rb
+++ b/judoscale-rails/test/railtie_test.rb
@@ -11,5 +11,9 @@ module Judoscale
     it "inserts the request middleware into the application middleware" do
       _(::Rails.application.config.middleware).must_include Judoscale::RequestMiddleware
     end
+
+    it "boots up a reporter automatically after the app/config is initialized" do
+      _(::Judoscale::Reporter.instance).must_be :started?
+    end
   end
 end

--- a/judoscale-rails/test/test_helper.rb
+++ b/judoscale-rails/test/test_helper.rb
@@ -6,11 +6,9 @@ require "judoscale-rails"
 require "minitest/autorun"
 require "minitest/spec"
 
-ENV["RACK_ENV"] ||= "test"
-require "rails"
-require "action_controller"
-
 ENV["DYNO"] ||= "web.1"
+ENV["RACK_ENV"] ||= "test"
+require "action_controller"
 
 class TestRailsApp < Rails::Application
   config.secret_key_base = "test-secret"

--- a/judoscale-rails/test/test_helper.rb
+++ b/judoscale-rails/test/test_helper.rb
@@ -10,6 +10,8 @@ ENV["RACK_ENV"] ||= "test"
 require "rails"
 require "action_controller"
 
+ENV["DYNO"] ||= "web.1"
+
 class TestRailsApp < Rails::Application
   config.secret_key_base = "test-secret"
   config.eager_load = false

--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -25,7 +25,7 @@ module Judoscale
     end
 
     def start!(config, metrics_collectors)
-      @started = true
+      @pid = Process.pid
 
       if !config.api_base_url
         logger.info "Reporter not started: JUDOSCALE_URL is not set"
@@ -56,13 +56,13 @@ module Judoscale
     end
 
     def started?
-      @started
+      @pid == Process.pid
     end
 
     def stop!
       @_thread&.terminate
       @_thread = nil
-      @started = false
+      @pid = nil
     end
 
     private

--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -32,6 +32,11 @@ module Judoscale
         return
       end
 
+      if metrics_collectors.empty?
+        logger.info "Reporter not started: no metrics need to be collected on this dyno"
+        return
+      end
+
       adapters_msg = Judoscale.adapters.map(&:identifier).join(", ")
       logger.info "Reporter starting, will report every #{config.report_interval_seconds} seconds or so. Adapters: [#{adapters_msg}]"
 

--- a/judoscale-ruby/lib/judoscale/web_metrics_collector.rb
+++ b/judoscale-ruby/lib/judoscale/web_metrics_collector.rb
@@ -5,6 +5,10 @@ require "judoscale/metrics_store"
 
 module Judoscale
   class WebMetricsCollector < MetricsCollector
+    def self.collect?(config)
+      config.dyno.start_with?("web.")
+    end
+
     def collect
       MetricsStore.instance.flush
     end

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -165,6 +165,13 @@ module Judoscale
 
         _(log_string).must_include "Reporter not started: no metrics need to be collected on this dyno"
       end
+
+      it "logs when the reporter starts successfully" do
+        stub_request(:post, "http://example.com/api/test-token/adapter/v1/metrics")
+        run_reporter_start_thread
+
+        _(log_string).must_include "Reporter starting, will report every 10 seconds or so. Adapters: [judoscale-ruby]"
+      end
     end
 
     describe "#report!" do

--- a/judoscale-ruby/test/web_metrics_collector_test.rb
+++ b/judoscale-ruby/test/web_metrics_collector_test.rb
@@ -8,10 +8,18 @@ module Judoscale
     let(:store) { MetricsStore.instance }
 
     describe ".collect?" do
-      it "always collects metrics data" do
-        config = Minitest::Mock.new
+      it "collects only from web dynos in the formation, to avoid unnecessary collection on workers" do
+        %w[web.1 web.15 web.101].each do |dyno|
+          Judoscale.configure { |config| config.dyno = dyno }
 
-        _(WebMetricsCollector.collect?(config)).must_equal true
+          _(WebMetricsCollector.collect?(Judoscale::Config.instance)).must_equal true
+        end
+
+        %w[worker.1 secondary.15 periodic.101].each do |dyno|
+          Judoscale.configure { |config| config.dyno = dyno }
+
+          _(WebMetricsCollector.collect?(Judoscale::Config.instance)).must_equal false
+        end
       end
     end
 


### PR DESCRIPTION
This adds a new `after_initialize` hook to the Railtie to start the reporter during the app boot, after all the other app config/initialization setup is done, which should give us access to the already configured Judoscale instance.

The way it's implemented is by running a new worker every time the process PID changes, so that if you're running a single thread server (e.g. Puma in thread mode only), you only get this initial reporter running, and it will be responsible for all collection & reporting. In cluster/workers mode, however, a reporter will be created during boot, and a new one for every forked process whenever a new request hits the request middleware, so each process get their own reporter thread. This is necessary because each process keeps an in-memory "store" of request metrics to flush every few seconds, and that store isn't shared among different processes, so we have each process run its own reporter thread and report the stored metrics on their own, a simple approach to make sure all processes are always covered, and that if a process is killed and restarted (e.g. by puma or unicorn), a new reporter can start again automatically to handle that new process as well.