### PR TITLE
Make all log levels behave the same consistencly

### DIFF
--- a/judoscale-ruby/lib/judoscale/logger.rb
+++ b/judoscale-ruby/lib/judoscale/logger.rb
@@ -14,36 +14,27 @@ module Judoscale
     TAG = "[Judoscale]"
     DEBUG_TAG = " [DEBUG]"
 
-    %w[ERROR WARN INFO].each do |severity_name|
+    %w[ERROR WARN INFO DEBUG].each do |severity_name|
       severity_level = ::Logger::Severity.const_get(severity_name)
 
       define_method(severity_name.downcase) do |*messages|
-        if log?(severity_level)
-          logger.add(severity_level) { tag(messages) }
-        end
-      end
-    end
-
-    def debug(*messages)
-      severity_level = ::Logger::Severity::DEBUG
-
-      if log?(severity_level)
         if log_level.nil?
-          logger.add(severity_level) { tag(messages, debug: true) }
-        else
-          logger.add(logger.level) { tag(messages, debug: true) }
+          logger.add(severity_level) { tag(messages) }
+        elsif severity_level >= log_level
+          if severity_level >= logger.level
+            logger.add(severity_level) { tag(messages) }
+          else
+            logger.add(logger.level) { tag(messages, tag_level: severity_name) }
+          end
         end
       end
     end
 
     private
 
-    def log?(severity_level)
-      log_level.nil? || severity_level >= log_level
-    end
-
-    def tag(msgs, debug: false)
-      msgs.map { |msg| "#{TAG}#{DEBUG_TAG if debug} #{msg}" }.join("\n")
+    def tag(msgs, tag_level: nil)
+      tag_level = " [#{tag_level}]" if tag_level
+      msgs.map { |msg| "#{TAG}#{tag_level} #{msg}" }.join("\n")
     end
   end
 end


### PR DESCRIPTION
If we don't have a configured log level, we'll just let the underlying
log level dictate whether the logging should really happen, no changes
here.

However, when there is a configured log level, we first determine if we
can proceed with logging at that level, otherwise we'll drop the message
on the floor. In other words, we don't log DEBUG if the configured log
level is INFO for example.

If we're allowed to log at the configured level, we'll just determine
if the underlying logger is allowed to log at that level too, to let it
through; otherwise it means we have enabled a lower log level than the
underlying logger, but we still want to ensure those logs are going to
the output, and we do that by prefixing/tagging them with the level,
e.g. `[Judoscale] [DEBUG]`.

### Sample

<details>

_Note: I had to reduce the quality quite a bit to upload it to GH here._

https://user-images.githubusercontent.com/26328/160031659-70dca5e4-00fb-4d5d-b831-5999c61575e7.mp4

</details>