### PR TITLE
Remove unused `Rails.version` definition from judoscale-ruby tests

### DIFF
--- a/judoscale-ruby/test/test_helper.rb
+++ b/judoscale-ruby/test/test_helper.rb
@@ -11,12 +11,6 @@ require "active_record"
 require "delayed_job"
 require "delayed_job_active_record"
 
-module Rails
-  def self.version
-    "5.0.fake"
-  end
-end
-
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 
 ActiveRecord::Schema.define do


### PR DESCRIPTION
This is no longer needed since we extracted judoscale-rails, I missed
removing it before.