### PR TITLE
Create global web & job test adapters for the judoscale-ruby test suite

### DIFF
--- a/judoscale-ruby/lib/judoscale-ruby.rb
+++ b/judoscale-ruby/lib/judoscale-ruby.rb
@@ -30,10 +30,6 @@ module Judoscale
     @adapters << Adapter.new(identifier, adapter_info, metrics_collector)
   end
 
-  def self.remove_adapter(identifier)
-    @adapters.delete_if { |adapter| adapter.identifier == identifier }
-  end
-
   add_adapter :"judoscale-ruby", {
     adapter_version: VERSION,
     language_version: RUBY_VERSION

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -18,7 +18,7 @@ module Judoscale
         enabled_adapter_configs = Config.adapter_configs.keys.select { |identifier|
           config.public_send(identifier).enabled
         }
-        _(enabled_adapter_configs).must_equal %i[delayed_job que]
+        _(enabled_adapter_configs).must_equal %i[delayed_job que test_job_config]
 
         enabled_adapter_configs.each do |adapter_name|
           adapter_config = config.public_send(adapter_name)
@@ -54,8 +54,8 @@ module Judoscale
         config.logger = test_logger
         config.max_request_size_bytes = 50_000
         config.report_interval_seconds = 20
-        config.delayed_job.max_queues = 100
-        config.delayed_job.track_busy_jobs = true
+        config.test_job_config.max_queues = 100
+        config.test_job_config.track_busy_jobs = true
         config.que.enabled = false
       end
 
@@ -66,15 +66,16 @@ module Judoscale
       _(config.logger).must_equal test_logger
       _(config.max_request_size_bytes).must_equal 50_000
       _(config.report_interval_seconds).must_equal 20
+      _(config.test_job_config.enabled).must_equal true
+      _(config.test_job_config.max_queues).must_equal 100
+      _(config.test_job_config.track_busy_jobs).must_equal true
       _(config.delayed_job.enabled).must_equal true
-      _(config.delayed_job.max_queues).must_equal 100
-      _(config.delayed_job.track_busy_jobs).must_equal true
       _(config.que.enabled).must_equal false
 
       enabled_adapter_configs = Config.adapter_configs.keys.select { |identifier|
         config.public_send(identifier).enabled
       }
-      _(enabled_adapter_configs).must_equal %i[delayed_job]
+      _(enabled_adapter_configs).must_equal %i[delayed_job test_job_config]
     end
 
     it "dumps the configuration options as json" do
@@ -90,6 +91,12 @@ module Judoscale
           track_busy_jobs: false
         },
         delayed_job: {
+          max_queues: 20,
+          queues: [],
+          queue_filter: false,
+          track_busy_jobs: false
+        },
+        test_job_config: {
           max_queues: 20,
           queues: [],
           queue_filter: false,

--- a/judoscale-ruby/test/test_helper.rb
+++ b/judoscale-ruby/test/test_helper.rb
@@ -40,7 +40,31 @@ ActiveRecord::Schema.define do
    # standard:enable all
 end
 
-module Judoscale::Test
+require "judoscale/job_metrics_collector"
+require "judoscale/web_metrics_collector"
+
+module Judoscale
+  module Test
+    class TestJobMetricsCollector < Judoscale::JobMetricsCollector
+      def self.adapter_identifier
+        :test_job_config
+      end
+
+      def collect
+        []
+      end
+    end
+
+    class TestWebMetricsCollector < Judoscale::WebMetricsCollector
+      def collect
+        [Metric.new(:qt, 1, Time.now)]
+      end
+    end
+  end
+
+  add_adapter :test_web, {}, metrics_collector: Test::TestWebMetricsCollector
+  add_adapter :test_job, {}, metrics_collector: Test::TestJobMetricsCollector
+  Config.add_adapter_config :test_job_config, Config::JobAdapterConfig
 end
 
 Dir[File.expand_path("./support/*.rb", __dir__)].sort.each { |file| require file }


### PR DESCRIPTION
Move the test adapters previously only used within the reporter test to
be available for the whole test suite. Having them setup globally allows
us to rely on a set world that contains a common scenario for testing
both the reporter and the configs, which are provided by the base
judoscale-ruby library.

It will also make it easier to extract the other adapters as we don't
need to rely on them so much for various config tests we were doing
before, since we now have a test job config readily available there.