### PR TITLE
Respect explicitly disabled job adapter from collecting metrics

### DIFF
--- a/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
@@ -10,7 +10,7 @@ module Judoscale
 
     # It's redundant to report these metrics from every dyno, so only report from the first one.
     def self.collect?(config)
-      config.dyno.num == 1
+      config.dyno.num == 1 && adapter_config.enabled
     end
 
     def self.adapter_name

--- a/judoscale-ruby/test/job_metrics_collector_test.rb
+++ b/judoscale-ruby/test/job_metrics_collector_test.rb
@@ -10,14 +10,27 @@ module Judoscale
         %w[web.1 worker.1 custom_type.1].each do |dyno|
           Judoscale.configure { |config| config.dyno = dyno }
 
-          _(JobMetricsCollector.collect?(Judoscale::Config.instance)).must_equal true
+          _(Test::TestJobMetricsCollector.collect?(Judoscale::Config.instance)).must_equal true
         end
 
         %w[web.2 worker.15 custom_type.101].each do |dyno|
           Judoscale.configure { |config| config.dyno = dyno }
 
-          _(JobMetricsCollector.collect?(Judoscale::Config.instance)).must_equal false
+          _(Test::TestJobMetricsCollector.collect?(Judoscale::Config.instance)).must_equal false
         end
+      end
+
+      it "skips collecting if the adapter has been explicitly disabled" do
+        Judoscale.configure { |config|
+          config.dyno = "web.1"
+          config.test_job_config.enabled = true
+        }
+
+        _(Test::TestJobMetricsCollector.collect?(Judoscale::Config.instance)).must_equal true
+
+        Judoscale.configure { |config| config.test_job_config.enabled = false }
+
+        _(Test::TestJobMetricsCollector.collect?(Judoscale::Config.instance)).must_equal false
       end
     end
   end

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -64,6 +64,23 @@ module Judoscale
         assert_mock reporter_mock
       end
 
+      it "respects explicitly disabled job adapters / metrics collectors via config when initializing the reporter" do
+        Judoscale.configure { |config| config.test_job_config.enabled = false }
+
+        reporter_mock = Minitest::Mock.new
+        reporter_mock.expect :started?, false
+        reporter_mock.expect :start!, true do |config, metrics_collectors|
+          _(metrics_collectors.size).must_equal 1
+          _(metrics_collectors[0]).must_be_instance_of Test::TestWebMetricsCollector
+        end
+
+        Reporter.stub(:instance, reporter_mock) {
+          Reporter.start(Config.instance)
+        }
+
+        assert_mock reporter_mock
+      end
+
       it "does not initialize the reporter more than once" do
         reporter_mock = Minitest::Mock.new
         reporter_mock.expect :started?, true


### PR DESCRIPTION
We were allowing job adapters to be disabled via configuration, but were
not honoring that anymore, I believe when moving from the worker
adapters that filtered those to the new job adapters infrastructure.
This ensures we respect the configuration and adds better tests to cover
it via the reporter.

Note: we're still logging that all judoscale adapters are running, but
that is not really true when you disable one job adapter via this
config. I'm looking into that separately.