### PR TITLE
Run tests & lint with Ruby 3.1

### DIFF
--- a/.github/workflows/judoscale-delayed_job-test.yml
+++ b/.github/workflows/judoscale-delayed_job-test.yml
@@ -18,6 +18,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/judoscale-delayed_job/${{ matrix.gemfile }}

--- a/.github/workflows/judoscale-que-test.yml
+++ b/.github/workflows/judoscale-que-test.yml
@@ -18,6 +18,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/judoscale-que/${{ matrix.gemfile }}

--- a/.github/workflows/judoscale-rails-test.yml
+++ b/.github/workflows/judoscale-rails-test.yml
@@ -18,6 +18,7 @@ jobs:
           # - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/judoscale-rails/${{ matrix.gemfile }}

--- a/.github/workflows/judoscale-resque-test.yml
+++ b/.github/workflows/judoscale-resque-test.yml
@@ -18,6 +18,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/judoscale-resque/${{ matrix.gemfile }}

--- a/.github/workflows/judoscale-ruby-test.yml
+++ b/.github/workflows/judoscale-ruby-test.yml
@@ -18,6 +18,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/judoscale-ruby/${{ matrix.gemfile }}

--- a/.github/workflows/judoscale-sidekiq-test.yml
+++ b/.github/workflows/judoscale-sidekiq-test.yml
@@ -18,6 +18,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/judoscale-sidekiq/${{ matrix.gemfile }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.0'
+          - '3.1'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Add Ruby 3.1 to the test matrix for all judoscale-* libs, and update lint action to run with Ruby 3.1.