### PR TITLE
Improve Reporter & Metrics Collectors initialization

### DIFF
--- a/judoscale-rails/lib/judoscale/rails/railtie.rb
+++ b/judoscale-rails/lib/judoscale/rails/railtie.rb
@@ -22,7 +22,7 @@ module Judoscale
       end
 
       config.after_initialize do
-        Reporter.start(Config.instance)
+        Reporter.start
       end
     end
   end

--- a/judoscale-ruby/lib/judoscale/adapter_api.rb
+++ b/judoscale-ruby/lib/judoscale/adapter_api.rb
@@ -15,7 +15,7 @@ module Judoscale
       @config = config
     end
 
-    def report_metrics!(report_json)
+    def report_metrics(report_json)
       post_json "/v1/metrics", report_json
     end
 

--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "singleton"
+require "judoscale/config"
 require "judoscale/logger"
 require "judoscale/adapter_api"
 require "judoscale/job_metrics_collector"
@@ -11,7 +12,7 @@ module Judoscale
     include Singleton
     include Logger
 
-    def self.start(config)
+    def self.start(config = Config.instance)
       unless instance.started?
         adapters = Judoscale.adapters
         metrics_collectors = adapters.map(&:metrics_collector)

--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -27,10 +27,10 @@ module Judoscale
       enabled_adapters = adapters.select { |adapter|
         adapter.metrics_collector.nil? || adapter.metrics_collector.collect?(config)
       }
-      metrics_collectors = enabled_adapters.map(&:metrics_collector)
-      metrics_collectors.compact!
+      metrics_collectors_classes = enabled_adapters.map(&:metrics_collector)
+      metrics_collectors_classes.compact!
 
-      if metrics_collectors.empty?
+      if metrics_collectors_classes.empty?
         logger.info "Reporter not started: no metrics need to be collected on this dyno"
         return
       end
@@ -38,7 +38,7 @@ module Judoscale
       adapters_msg = enabled_adapters.map(&:identifier).join(", ")
       logger.info "Reporter starting, will report every #{config.report_interval_seconds} seconds or so. Adapters: [#{adapters_msg}]"
 
-      metrics_collectors.map!(&:new)
+      metrics_collectors = metrics_collectors_classes.map(&:new)
 
       run_loop(config, metrics_collectors)
     end

--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -58,7 +58,7 @@ module Judoscale
         log_exceptions { metric_collector.collect }
       end
 
-      log_exceptions { report!(config, metrics) }
+      log_exceptions { report(config, metrics) }
     end
 
     def started?
@@ -73,10 +73,10 @@ module Judoscale
 
     private
 
-    def report!(config, metrics)
+    def report(config, metrics)
       report = Report.new(Judoscale.adapters, config, metrics)
       logger.info "Reporting #{report.metrics.size} metrics"
-      result = AdapterApi.new(config).report_metrics!(report.as_json)
+      result = AdapterApi.new(config).report_metrics(report.as_json)
 
       case result
       when AdapterApi::SuccessResponse

--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -24,16 +24,18 @@ module Judoscale
         return
       end
 
-      metrics_collectors = adapters.map(&:metrics_collector)
+      enabled_adapters = adapters.select { |adapter|
+        adapter.metrics_collector.nil? || adapter.metrics_collector.collect?(config)
+      }
+      metrics_collectors = enabled_adapters.map(&:metrics_collector)
       metrics_collectors.compact!
-      metrics_collectors.select! { |mc| mc.collect?(config) }
 
       if metrics_collectors.empty?
         logger.info "Reporter not started: no metrics need to be collected on this dyno"
         return
       end
 
-      adapters_msg = adapters.map(&:identifier).join(", ")
+      adapters_msg = enabled_adapters.map(&:identifier).join(", ")
       logger.info "Reporter starting, will report every #{config.report_interval_seconds} seconds or so. Adapters: [#{adapters_msg}]"
 
       metrics_collectors.map!(&:new)

--- a/judoscale-ruby/lib/judoscale/request_metrics.rb
+++ b/judoscale-ruby/lib/judoscale/request_metrics.rb
@@ -4,7 +4,7 @@ module Judoscale
   class RequestMetrics
     attr_reader :request_id, :size, :network_time
 
-    def initialize(env, config)
+    def initialize(env, config = Config.instance)
       @config = config
       @request_id = env["HTTP_X_REQUEST_ID"]
       @size = env["rack.input"].respond_to?(:size) ? env["rack.input"].size : 0

--- a/judoscale-ruby/lib/judoscale/request_middleware.rb
+++ b/judoscale-ruby/lib/judoscale/request_middleware.rb
@@ -2,7 +2,6 @@
 
 require "judoscale/metrics_store"
 require "judoscale/reporter"
-require "judoscale/config"
 require "judoscale/logger"
 require "judoscale/request_metrics"
 
@@ -15,15 +14,14 @@ module Judoscale
     end
 
     def call(env)
-      config = Config.instance
-      request_metrics = RequestMetrics.new(env, config)
+      request_metrics = RequestMetrics.new(env)
 
       unless request_metrics.ignore?
         queue_time = request_metrics.queue_time
         network_time = request_metrics.network_time
       end
 
-      Reporter.start(config)
+      Reporter.start
 
       if queue_time
         store = MetricsStore.instance

--- a/judoscale-ruby/test/adapter_api_test.rb
+++ b/judoscale-ruby/test/adapter_api_test.rb
@@ -7,14 +7,14 @@ describe Judoscale::AdapterApi do
   let(:report_params) { {dyno: "web.1", metrics: [[Time.now.to_i, 11, "qt"], [Time.now.to_i, 33, "qt"]]} }
   let(:config) { Struct.new(:api_base_url).new("http://example.com") }
 
-  describe "#report_metrics!" do
+  describe "#report_metrics" do
     it "returns a successful response" do
       config.api_base_url = "http://judoscale.dev/api/test-app-token"
       stub = stub_request(:post, "http://judoscale.dev/api/test-app-token/v1/metrics")
         .to_return(status: 200)
 
       adapter_api = Judoscale::AdapterApi.new(config)
-      result = adapter_api.report_metrics!(report_params)
+      result = adapter_api.report_metrics(report_params)
 
       _(result).must_be_instance_of Judoscale::AdapterApi::SuccessResponse
       assert_requested stub
@@ -26,7 +26,7 @@ describe Judoscale::AdapterApi do
         .to_return(status: [400, "Bad Request"])
 
       adapter_api = Judoscale::AdapterApi.new(config)
-      result = adapter_api.report_metrics!(report_params)
+      result = adapter_api.report_metrics(report_params)
 
       _(result).must_be_instance_of Judoscale::AdapterApi::FailureResponse
       _(result.failure_message).must_equal "400 - Bad Request"
@@ -39,7 +39,7 @@ describe Judoscale::AdapterApi do
         .to_return(status: [503, "Service Unavailable"])
 
       adapter_api = Judoscale::AdapterApi.new(config)
-      result = adapter_api.report_metrics!(report_params)
+      result = adapter_api.report_metrics(report_params)
 
       _(result).must_be_instance_of Judoscale::AdapterApi::FailureResponse
       _(result.failure_message).must_equal "503 - Service Unavailable"
@@ -52,7 +52,7 @@ describe Judoscale::AdapterApi do
         .to_return(status: 200)
 
       adapter_api = Judoscale::AdapterApi.new(config)
-      result = adapter_api.report_metrics!(report_params)
+      result = adapter_api.report_metrics(report_params)
 
       _(result).must_be_instance_of Judoscale::AdapterApi::SuccessResponse
       assert_requested stub

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -100,7 +100,7 @@ module Judoscale
 
       def run_reporter_start_thread(collectors: [Test::TestWebMetricsCollector.new])
         stub_reporter_loop {
-          reporter_thread = Reporter.instance.start!(Config.instance, collectors)
+          reporter_thread = Reporter.instance.start!(Config.instance, collectors, Judoscale.adapters)
           reporter_thread.join
         }
       end
@@ -150,7 +150,7 @@ module Judoscale
         Judoscale.configure { |config| config.api_base_url = nil }
 
         Thread.stub(:new, ->(*) { raise "SHOULD NOT BE CALLED" }) {
-          Reporter.instance.start!(Config.instance, [Test::TestWebMetricsCollector.new])
+          Reporter.instance.start!(Config.instance, [Test::TestWebMetricsCollector.new], Judoscale.adapters)
         }
 
         _(log_string).must_include "Reporter not started: JUDOSCALE_URL is not set"
@@ -158,7 +158,7 @@ module Judoscale
 
       it "does not run the reporter thread when there are no metrics collectors" do
         Thread.stub(:new, ->(*) { raise "SHOULD NOT BE CALLED" }) {
-          Reporter.instance.start!(Config.instance, [])
+          Reporter.instance.start!(Config.instance, [], Judoscale.adapters)
         }
 
         _(log_string).must_include "Reporter not started: no metrics need to be collected on this dyno"

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -24,7 +24,7 @@ module Judoscale
         end
 
         Reporter.stub(:instance, reporter_mock) {
-          Reporter.start(Config.instance)
+          Reporter.start
         }
 
         assert_mock reporter_mock
@@ -41,7 +41,7 @@ module Judoscale
         end
 
         Reporter.stub(:instance, reporter_mock) {
-          Reporter.start(Config.instance)
+          Reporter.start
         }
 
         assert_mock reporter_mock
@@ -75,7 +75,7 @@ module Judoscale
         end
 
         Reporter.stub(:instance, reporter_mock) {
-          Reporter.start(Config.instance)
+          Reporter.start
         }
 
         assert_mock reporter_mock
@@ -86,7 +86,7 @@ module Judoscale
         reporter_mock.expect :started?, true
 
         Reporter.stub(:instance, reporter_mock) {
-          Reporter.start(Config.instance)
+          Reporter.start
         }
 
         assert_mock reporter_mock

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -147,6 +147,15 @@ module Judoscale
 
         _(log_string).must_include "Reporter starting, will report every 10 seconds or so. Adapters: [judoscale-ruby, test_web, test_job]"
       end
+
+      it "logs only enabled adapters" do
+        Judoscale.configure { |config| config.test_job_config.enabled = false }
+
+        stub_request(:post, "http://example.com/api/test-token/v1/metrics")
+        run_reporter_start_thread
+
+        _(log_string).must_include "Reporter starting, will report every 10 seconds or so. Adapters: [judoscale-ruby, test_web]"
+      end
     end
 
     describe "#run_metrics_collection" do

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -14,65 +14,10 @@ module Judoscale
     }
 
     describe ".start" do
-      it "initializes the reporter with all registered web and job metrics collectors when on the first dyno" do
+      it "initializes the reporter with the current configuration and loaded adapters" do
         reporter_mock = Minitest::Mock.new
         reporter_mock.expect :started?, false
-        reporter_mock.expect :start!, true do |config, metrics_collectors|
-          _(metrics_collectors.size).must_equal 2
-          _(metrics_collectors[0]).must_be_instance_of Test::TestWebMetricsCollector
-          _(metrics_collectors[1]).must_be_instance_of Test::TestJobMetricsCollector
-        end
-
-        Reporter.stub(:instance, reporter_mock) {
-          Reporter.start
-        }
-
-        assert_mock reporter_mock
-      end
-
-      it "initializes the reporter only with registered web metrics collectors on subsequent dynos to avoid redundant worker metrics" do
-        Judoscale.configure { |config| config.dyno = "web.2" }
-
-        reporter_mock = Minitest::Mock.new
-        reporter_mock.expect :started?, false
-        reporter_mock.expect :start!, true do |config, metrics_collectors|
-          _(metrics_collectors.size).must_equal 1
-          _(metrics_collectors[0]).must_be_instance_of Test::TestWebMetricsCollector
-        end
-
-        Reporter.stub(:instance, reporter_mock) {
-          Reporter.start
-        }
-
-        assert_mock reporter_mock
-      end
-
-      it "initializes the reporter only with registered job metrics collectors on the first non-web dyno to avoid unnecessary web collection attempts" do
-        Judoscale.configure { |config| config.dyno = "worker.1" }
-
-        reporter_mock = Minitest::Mock.new
-        reporter_mock.expect :started?, false
-        reporter_mock.expect :start!, true do |config, metrics_collectors|
-          _(metrics_collectors.size).must_equal 1
-          _(metrics_collectors[0]).must_be_instance_of Test::TestJobMetricsCollector
-        end
-
-        Reporter.stub(:instance, reporter_mock) {
-          Reporter.start(Config.instance)
-        }
-
-        assert_mock reporter_mock
-      end
-
-      it "respects explicitly disabled job adapters / metrics collectors via config when initializing the reporter" do
-        Judoscale.configure { |config| config.test_job_config.enabled = false }
-
-        reporter_mock = Minitest::Mock.new
-        reporter_mock.expect :started?, false
-        reporter_mock.expect :start!, true do |config, metrics_collectors|
-          _(metrics_collectors.size).must_equal 1
-          _(metrics_collectors[0]).must_be_instance_of Test::TestWebMetricsCollector
-        end
+        reporter_mock.expect :start!, true, [Config.instance, Judoscale.adapters]
 
         Reporter.stub(:instance, reporter_mock) {
           Reporter.start
@@ -98,9 +43,9 @@ module Judoscale
         Reporter.instance.stop!
       }
 
-      def run_reporter_start_thread(collectors: [Test::TestWebMetricsCollector.new])
+      def run_reporter_start_thread
         stub_reporter_loop {
-          reporter_thread = Reporter.instance.start!(Config.instance, collectors, Judoscale.adapters)
+          reporter_thread = Reporter.instance.start!(Config.instance, Judoscale.adapters)
           reporter_thread.join
         }
       end
@@ -113,52 +58,84 @@ module Judoscale
         }
       end
 
-      it "sends a report with collected metrics" do
-        metrics_collector = Test::TestWebMetricsCollector.new
-        metrics = metrics_collector.collect
+      it "sends a report with collected metrics in the reporter thread loop" do
+        web_metrics = Test::TestWebMetricsCollector.new.collect
+        job_metrics = Test::TestJobMetricsCollector.new.collect
+        all_metrics = web_metrics + job_metrics
 
-        expected_body = Report.new(Judoscale.adapters, Config.instance, metrics).as_json
+        expected_body = Report.new(Judoscale.adapters, Config.instance, all_metrics).as_json
         stub = stub_request(:post, "http://example.com/api/test-token/v1/metrics")
           .with(body: JSON.generate(expected_body))
 
-        run_reporter_start_thread(collectors: [metrics_collector])
+        run_reporter_start_thread
 
         assert_requested stub
       end
 
-      it "logs exceptions when reporting collected information" do
-        Reporter.instance.stub(:report!, ->(*) { raise "REPORT BOOM!" }) {
-          run_reporter_start_thread
-        }
+      it "initializes the reporter with all registered web and job metrics collectors when on the first dyno" do
+        run_loop_stub = proc do |config, metrics_collectors|
+          _(metrics_collectors.size).must_equal 2
+          _(metrics_collectors[0]).must_be_instance_of Test::TestWebMetricsCollector
+          _(metrics_collectors[1]).must_be_instance_of Test::TestJobMetricsCollector
+        end
 
-        _(log_string).must_include "Reporter error: #<RuntimeError: REPORT BOOM!>"
-        _(log_string).must_include "lib/judoscale/reporter.rb"
+        Reporter.instance.stub(:run_loop, run_loop_stub) {
+          Reporter.instance.start!(Config.instance, Judoscale.adapters)
+        }
       end
 
-      it "logs exceptions when collecting information" do
-        metrics_collector = Test::TestWebMetricsCollector.new
+      it "initializes the reporter only with registered web metrics collectors on subsequent dynos to avoid redundant worker metrics" do
+        Judoscale.configure { |config| config.dyno = "web.2" }
 
-        metrics_collector.stub(:collect, ->(*) { raise "ADAPTER BOOM!" }) {
-          run_reporter_start_thread(collectors: [metrics_collector])
+        run_loop_stub = proc do |config, metrics_collectors|
+          _(metrics_collectors.size).must_equal 1
+          _(metrics_collectors[0]).must_be_instance_of Test::TestWebMetricsCollector
+        end
+
+        Reporter.instance.stub(:run_loop, run_loop_stub) {
+          Reporter.instance.start!(Config.instance, Judoscale.adapters)
         }
+      end
 
-        _(log_string).must_include "Reporter error: #<RuntimeError: ADAPTER BOOM!>"
-        _(log_string).must_include "lib/judoscale/reporter.rb"
+      it "initializes the reporter only with registered job metrics collectors on the first non-web dyno to avoid unnecessary web collection attempts" do
+        Judoscale.configure { |config| config.dyno = "worker.1" }
+
+        run_loop_stub = proc do |config, metrics_collectors|
+          _(metrics_collectors.size).must_equal 1
+          _(metrics_collectors[0]).must_be_instance_of Test::TestJobMetricsCollector
+        end
+
+        Reporter.instance.stub(:run_loop, run_loop_stub) {
+          Reporter.instance.start!(Config.instance, Judoscale.adapters)
+        }
+      end
+
+      it "respects explicitly disabled job adapters / metrics collectors via config when initializing the reporter" do
+        Judoscale.configure { |config| config.test_job_config.enabled = false }
+
+        run_loop_stub = proc do |config, metrics_collectors|
+          _(metrics_collectors.size).must_equal 1
+          _(metrics_collectors[0]).must_be_instance_of Test::TestWebMetricsCollector
+        end
+
+        Reporter.instance.stub(:run_loop, run_loop_stub) {
+          Reporter.instance.start!(Config.instance, Judoscale.adapters)
+        }
       end
 
       it "does not run the reporter thread when the API url is not configured" do
         Judoscale.configure { |config| config.api_base_url = nil }
 
-        Thread.stub(:new, ->(*) { raise "SHOULD NOT BE CALLED" }) {
-          Reporter.instance.start!(Config.instance, [Test::TestWebMetricsCollector.new], Judoscale.adapters)
+        Reporter.instance.stub(:run_loop, ->(*) { raise "SHOULD NOT BE CALLED" }) {
+          Reporter.instance.start!(Config.instance, Judoscale.adapters)
         }
 
         _(log_string).must_include "Reporter not started: JUDOSCALE_URL is not set"
       end
 
       it "does not run the reporter thread when there are no metrics collectors" do
-        Thread.stub(:new, ->(*) { raise "SHOULD NOT BE CALLED" }) {
-          Reporter.instance.start!(Config.instance, [], Judoscale.adapters)
+        Reporter.instance.stub(:run_loop, ->(*) { raise "SHOULD NOT BE CALLED" }) {
+          Reporter.instance.start!(Config.instance, Judoscale.adapters.select { |a| a.metrics_collector.nil? })
         }
 
         _(log_string).must_include "Reporter not started: no metrics need to be collected on this dyno"
@@ -169,6 +146,28 @@ module Judoscale
         run_reporter_start_thread
 
         _(log_string).must_include "Reporter starting, will report every 10 seconds or so. Adapters: [judoscale-ruby, test_web, test_job]"
+      end
+    end
+
+    describe "#run_metrics_collection" do
+      it "logs exceptions when reporting collected information" do
+        Reporter.instance.stub(:report!, ->(*) { raise "REPORT BOOM!" }) {
+          Reporter.instance.run_metrics_collection(Config.instance, [Test::TestWebMetricsCollector.new])
+        }
+
+        _(log_string).must_include "Reporter error: #<RuntimeError: REPORT BOOM!>"
+        _(log_string).must_include "lib/judoscale/reporter.rb"
+      end
+
+      it "logs exceptions when collecting information" do
+        metrics_collector = Test::TestWebMetricsCollector.new
+
+        metrics_collector.stub(:collect, ->(*) { raise "ADAPTER BOOM!" }) {
+          Reporter.instance.run_metrics_collection(Config.instance, [metrics_collector])
+        }
+
+        _(log_string).must_include "Reporter error: #<RuntimeError: ADAPTER BOOM!>"
+        _(log_string).must_include "lib/judoscale/reporter.rb"
       end
     end
 

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -176,7 +176,7 @@ module Judoscale
       end
 
       it "logs exceptions when reporting collected information" do
-        Reporter.instance.stub(:report!, ->(*) { raise "REPORT BOOM!" }) {
+        Reporter.instance.stub(:report, ->(*) { raise "REPORT BOOM!" }) {
           Reporter.instance.run_metrics_collection(Config.instance, [Test::TestWebMetricsCollector.new])
         }
 

--- a/judoscale-ruby/test/test_helper.rb
+++ b/judoscale-ruby/test/test_helper.rb
@@ -18,7 +18,7 @@ module Judoscale
       end
 
       def collect
-        []
+        [Metric.new(:qt, 2, Time.now, "test-queue")]
       end
     end
 


### PR DESCRIPTION
This moves the initialization of metrics collectors down in the reporter start logic, so that we can perform initial checks like whether the adapter URL is set, before initializing collectors, which is helpful especially in development where you may not have it set.

In order to make that refactoring easier and hopefully the code a bit easier to maintain, I split the reporter start method into a couple more, one for running the reporter loop, and another internal one that just runs a single collection. Aside from giving names to those actions, it allows us to test one or another behavior more specifically through those methods.

It also fixes the logging of adapters to only output the ones that are really enabled, in case the user purposefully loaded but disabled one of the job adapters.