### PR TITLE
Fix reporting other metrics when an exception happens in one collector

### DIFF
--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -57,7 +57,7 @@ module Judoscale
 
     def run_metrics_collection(config, metrics_collectors)
       metrics = metrics_collectors.flat_map do |metric_collector|
-        log_exceptions { metric_collector.collect }
+        log_exceptions { metric_collector.collect } || []
       end
 
       log_exceptions { report(config, metrics) }
@@ -95,6 +95,7 @@ module Judoscale
       # Note: Exceptions in threads other than the main thread will fail silently and terminate it.
       # https://ruby-doc.org/core-3.1.0/Thread.html#class-Thread-label-Exception+handling
       logger.error "Reporter error: #{ex.inspect}", *ex.backtrace
+      nil
     end
   end
 end


### PR DESCRIPTION
If one metrics collector happened to throw an exception during the
collection, we were incorrectly returning the value of `logger.error`
(an integer) and adding it to the metrics array for later reporting,
which would then fail with another exception that was logged as a
`NoMethodError`, trying to call methods on it as if it was a `Metric`
instance.

I hit this while trying to run the Sidekiq sample app without having
redis running locally: it'd blow up in the Sidekiq collection, and
bubble that up to the report step, logging two different exceptions:

    ERROR: [Judoscale] Reporter error: #<Redis::CannotConnectError:
    Error connecting to Redis on 127.0.0.1:6379 (Errno::ECONNREFUSED)>

    ...

    ERROR: [Judoscale] Reporter error: #<NoMethodError:
    undefined method `time' for 5080:Integer
    Did you mean?  times>

The second message demonstrates that the first collection attempt
returned `5080` from the `logger.error` call, which was added to the
metrics array in memory for report, failing with the `NoMethodError`.

Now we ensure nothing returns from the collect attempt if there's an
exception, and will fallback to an empty array for that collector so we
can report the other metrics successfully.