### PR TITLE
Add home page with some basic instructions for sample apps

### DIFF
--- a/sample-apps/rails-sample/app/controllers/home_controller.rb
+++ b/sample-apps/rails-sample/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/sample-apps/rails-sample/app/views/home/index.html.erb
+++ b/sample-apps/rails-sample/app/views/home/index.html.erb
@@ -1,0 +1,8 @@
+<h1>Judoscale: Rails Sample</h1>
+
+<p>
+  Judoscale is reporting metrics to <a href="https://judoscale-adapter-mock.requestcatcher.com" target="_blank" rel="noreferrer">https://judoscale-adapter-mock.requestcatcher.com</a>.
+</p>
+<p>
+  Open that page to watch as metrics are being reported, and reload this page multiple times to collect and report web metrics.
+</p>

--- a/sample-apps/rails-sample/app/views/layouts/application.html.erb
+++ b/sample-apps/rails-sample/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>RailsSample</title>
+    <title>Judoscale: Rails Sample</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/sample-apps/rails-sample/config/routes.rb
+++ b/sample-apps/rails-sample/config/routes.rb
@@ -1,2 +1,3 @@
 Rails.application.routes.draw do
+  root to: "home#index"
 end

--- a/sample-apps/sidekiq-sample/app/views/jobs/index.html.erb
+++ b/sample-apps/sidekiq-sample/app/views/jobs/index.html.erb
@@ -1,4 +1,16 @@
-<h1>Sidekiq Queues</h1>
+<h1>Judoscale: Sidekiq Sample</h1>
+
+<p>
+  Judoscale is reporting metrics to <a href="https://judoscale-adapter-mock.requestcatcher.com" target="_blank" rel="noreferrer">https://judoscale-adapter-mock.requestcatcher.com</a>.
+</p>
+<p>
+  Open that page to watch as metrics are being reported, and reload this page multiple times to collect and report web metrics.
+</p>
+<p>
+  Enqueue test jobs using the form below. They will be slowly processed by Sidekiq, while Judoscale collects and reports available queue metrics.
+</p>
+
+<h2>Sidekiq Queues</h2>
 
 <% if notice %><p style="color:green"><%= notice %><% end %>
 <% if alert %><p style="color:red"><%= alert %><% end %>
@@ -9,7 +21,7 @@
   <% end %>
 </ul>
 
-<h2>Enqueue Jobs</h2>
+<h3>Enqueue Jobs</h3>
 
 <%= form_with scope: :job, url: jobs_path, method: :post do |f| %>
   <div>

--- a/sample-apps/sidekiq-sample/app/views/layouts/application.html.erb
+++ b/sample-apps/sidekiq-sample/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>SidekiqSample</title>
+    <title>Judoscale: Sidekiq Sample</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/sample-apps/sidekiq-sample/config/environments/development.rb
+++ b/sample-apps/sidekiq-sample/config/environments/development.rb
@@ -48,6 +48,8 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   # config.active_record.verbose_query_logs = true
 
+  config.log_level = ENV.fetch("LOG_LEVEL", :debug)
+
   # Suppress logger output for asset requests.
   # config.assets.quiet = true
 


### PR DESCRIPTION
I kept trying to remember the URL to go to, and looking it up in the readme, so I thought we could do a bit of copy to the apps that would include that and some general instructions:

<img width="975" alt="Screen Shot 2022-04-04 at 19 11 48" src="https://user-images.githubusercontent.com/26328/161641412-6c97ae45-c5a5-40fb-a6a1-9580fa5e342f.png">

<img width="861" alt="Screen Shot 2022-04-04 at 19 11 38" src="https://user-images.githubusercontent.com/26328/161641406-7a60eaec-fe91-4ad4-ba8c-05ca8fd3012d.png">
