### PR TITLE
Remove unused default timezone method from AR helpers

### DIFF
--- a/judoscale-ruby/lib/judoscale/job_metrics_collector/active_record_helper.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector/active_record_helper.rb
@@ -3,16 +3,6 @@ module Judoscale
     module ActiveRecordHelper
       private
 
-      def default_timezone
-        if ::ActiveRecord.respond_to?(:default_timezone)
-          # Rails >= 7
-          ::ActiveRecord.default_timezone
-        else
-          # Rails < 7
-          ::ActiveRecord::Base.default_timezone
-        end
-      end
-
       def select_rows_silently(sql)
         if Config.instance.log_level && ::ActiveRecord::Base.logger.respond_to?(:silence)
           ::ActiveRecord::Base.logger.silence(Config.instance.log_level) { select_rows(sql) }


### PR DESCRIPTION
We decided to no longer log this with the AR based job adapters, so we
can remove the method safely as it's not used anywhere.

Reference: https://github.com/judoscale/judoscale-ruby/pull/64#discussion_r837548643