### PR TITLE
Move Que tests to postgres

### DIFF
--- a/.github/workflows/judoscale-que-test.yml
+++ b/.github/workflows/judoscale-que-test.yml
@@ -22,6 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/judoscale-que/${{ matrix.gemfile }}
+    services:
+      db:
+        image: postgres:latest
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/judoscale-que/.tool-versions
+++ b/judoscale-que/.tool-versions
@@ -1,0 +1,1 @@
+postgres 14.2

--- a/judoscale-que/Gemfile
+++ b/judoscale-que/Gemfile
@@ -4,6 +4,6 @@ gemspec
 
 gem "judoscale-ruby", path: "../judoscale-ruby"
 gem "activerecord", "~> 6.1"
-gem "sqlite3", platforms: :ruby
+gem "pg"
 gem "minitest"
 gem "rake"

--- a/judoscale-que/Gemfile.lock
+++ b/judoscale-que/Gemfile.lock
@@ -28,9 +28,9 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     minitest (5.15.0)
+    pg (1.3.5)
     que (1.4.0)
     rake (13.0.6)
-    sqlite3 (1.4.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     zeitwerk (2.5.4)
@@ -46,8 +46,8 @@ DEPENDENCIES
   judoscale-que!
   judoscale-ruby!
   minitest
+  pg
   rake
-  sqlite3
 
 BUNDLED WITH
    2.3.8

--- a/judoscale-que/test/metrics_collector_test.rb
+++ b/judoscale-que/test/metrics_collector_test.rb
@@ -8,8 +8,8 @@ module Judoscale
   describe Que::MetricsCollector do
     def enqueue(queue, run_at)
       ActiveRecord::Base.connection.insert <<~SQL
-        INSERT INTO que_jobs (queue, run_at)
-        VALUES ('#{queue}', '#{run_at.iso8601(6)}')
+        INSERT INTO que_jobs (job_class, queue, run_at)
+        VALUES ('TestJob', '#{queue}', '#{run_at.iso8601(6)}')
       SQL
     end
 

--- a/judoscale-que/test/metrics_collector_test.rb
+++ b/judoscale-que/test/metrics_collector_test.rb
@@ -29,10 +29,10 @@ module Judoscale
 
         _(metrics.size).must_equal 2
         _(metrics[0].queue_name).must_equal "default"
-        _(metrics[0].value).must_be_within_delta 11000, 5
+        _(metrics[0].value).must_be_within_delta 11000, 10
         _(metrics[0].identifier).must_equal :qt
         _(metrics[1].queue_name).must_equal "high"
-        _(metrics[1].value).must_be_within_delta 22222, 5
+        _(metrics[1].value).must_be_within_delta 22222, 10
         _(metrics[1].identifier).must_equal :qt
       end
 

--- a/judoscale-que/test/test_helper.rb
+++ b/judoscale-que/test/test_helper.rb
@@ -8,20 +8,18 @@ require "minitest/spec"
 
 require "active_record"
 
-ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+DATABASE_NAME = "judoscale_que_test"
+DATABASE_USERNAME = "postgres"
+ENV["DATABASE_URL"] ||= "postgres://#{DATABASE_USERNAME}:@localhost/#{DATABASE_NAME}"
 
-ActiveRecord::Schema.define do
-  # standard:disable all
-  create_table "que_jobs" do |t|
-    t.integer "priority", limit: 2, default: 100, null: false
-    t.datetime "run_at", null: false
-    t.integer "error_count", default: 0, null: false
-    t.text "queue", default: "default", null: false
-    t.datetime "finished_at"
-    t.datetime "expired_at"
-  end
-   # standard:enable all
-end
+ActiveRecord::Tasks::DatabaseTasks.create_all
+Minitest.after_run {
+  ActiveRecord::Tasks::DatabaseTasks.drop_all
+}
+ActiveRecord::Base.establish_connection
+
+Que.connection = ActiveRecord
+Que::Migrations.migrate!(version: Que::Migrations::CURRENT_VERSION)
 
 module Judoscale::Test
 end


### PR DESCRIPTION
Create and drop the test database for each run, and migrate Que using its own migration function to ensure we have the most up-to-date tables setup for our testing.

Que is really meant to be used with postgres, so using it for our tests will allow us to have more realistic tests and possibly fix any postgres specific issues with Que usage.