### PR TITLE
Remove sqlite3 dependency from sample apps that do not use it

### DIFF
--- a/sample-apps/rails-sample/Gemfile
+++ b/sample-apps/rails-sample/Gemfile
@@ -6,7 +6,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   gem rails_gem, "~> 7.0.1"
 }
 
-gem "sqlite3", "~> 1.4"
 gem "puma", "~> 5.0"
 
 # Need to reference both, otherwise it'd use the `judoscale-rails` gemspec to try to find `judoscale-ruby`,

--- a/sample-apps/rails-sample/Gemfile.lock
+++ b/sample-apps/rails-sample/Gemfile.lock
@@ -66,7 +66,6 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
-    sqlite3 (1.4.2)
     thor (1.2.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -84,7 +83,6 @@ DEPENDENCIES
   judoscale-ruby!
   puma (~> 5.0)
   railties (~> 7.0.1)
-  sqlite3 (~> 1.4)
 
 BUNDLED WITH
    2.3.9

--- a/sample-apps/resque-sample/Gemfile
+++ b/sample-apps/resque-sample/Gemfile
@@ -6,7 +6,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   gem rails_gem, "~> 7.0.1"
 }
 
-gem "sqlite3", "~> 1.4"
 gem "puma", "~> 5.0"
 
 gem "resque"

--- a/sample-apps/resque-sample/Gemfile.lock
+++ b/sample-apps/resque-sample/Gemfile.lock
@@ -93,7 +93,6 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.0)
       tilt (~> 2.0)
-    sqlite3 (1.4.2)
     thor (1.2.1)
     tilt (2.0.10)
     tzinfo (2.0.4)
@@ -114,7 +113,6 @@ DEPENDENCIES
   puma (~> 5.0)
   railties (~> 7.0.1)
   resque
-  sqlite3 (~> 1.4)
 
 BUNDLED WITH
    2.3.8

--- a/sample-apps/sidekiq-sample/Gemfile
+++ b/sample-apps/sidekiq-sample/Gemfile
@@ -6,7 +6,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   gem rails_gem, "~> 7.0.1"
 }
 
-gem "sqlite3", "~> 1.4"
 gem "puma", "~> 5.0"
 
 gem "sidekiq", "~> 6.4"

--- a/sample-apps/sidekiq-sample/Gemfile.lock
+++ b/sample-apps/sidekiq-sample/Gemfile.lock
@@ -79,7 +79,6 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sqlite3 (1.4.2)
     thor (1.2.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -99,7 +98,6 @@ DEPENDENCIES
   puma (~> 5.0)
   railties (~> 7.0.1)
   sidekiq (~> 6.4)
-  sqlite3 (~> 1.4)
 
 BUNDLED WITH
    2.3.8


### PR DESCRIPTION
I had removed Active Record as a dependency from these sample apps
(Rails, Sidekiq, Resque) since they don't really need / use it, but I
missed removing the sqlite3 db dependency as well.