### PR TITLE
Move DelayedJob adapter tests to PostgreSQL

### DIFF
--- a/.github/workflows/judoscale-delayed_job-test.yml
+++ b/.github/workflows/judoscale-delayed_job-test.yml
@@ -22,6 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/judoscale-delayed_job/${{ matrix.gemfile }}
+    services:
+      db:
+        image: postgres:latest
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/judoscale-delayed_job/Gemfile
+++ b/judoscale-delayed_job/Gemfile
@@ -4,6 +4,6 @@ gemspec
 
 gem "judoscale-ruby", path: "../judoscale-ruby"
 gem "activerecord", "~> 6.1"
-gem "sqlite3", platforms: :ruby
+gem "pg"
 gem "minitest"
 gem "rake"

--- a/judoscale-delayed_job/Gemfile.lock
+++ b/judoscale-delayed_job/Gemfile.lock
@@ -33,8 +33,8 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     minitest (5.15.0)
+    pg (1.3.5)
     rake (13.0.6)
-    sqlite3 (1.4.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     zeitwerk (2.5.4)
@@ -50,8 +50,8 @@ DEPENDENCIES
   judoscale-delayed_job!
   judoscale-ruby!
   minitest
+  pg
   rake
-  sqlite3
 
 BUNDLED WITH
    2.3.8

--- a/judoscale-delayed_job/test/test_helper.rb
+++ b/judoscale-delayed_job/test/test_helper.rb
@@ -8,7 +8,15 @@ require "minitest/spec"
 
 require "active_record"
 
-ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+DATABASE_NAME = "judoscale_delayed_job_test"
+DATABASE_USERNAME = "postgres"
+DATABASE_URL = "postgres://#{DATABASE_USERNAME}:@localhost/#{DATABASE_NAME}"
+
+ActiveRecord::Tasks::DatabaseTasks.create(DATABASE_URL)
+Minitest.after_run {
+  ActiveRecord::Tasks::DatabaseTasks.drop(DATABASE_URL)
+}
+ActiveRecord::Base.establish_connection(DATABASE_URL)
 
 ActiveRecord::Schema.define do
   # https://github.com/collectiveidea/delayed_job_active_record/blob/master/lib/generators/delayed_job/templates/migration.rb#L3

--- a/judoscale-que/test/test_helper.rb
+++ b/judoscale-que/test/test_helper.rb
@@ -10,13 +10,13 @@ require "active_record"
 
 DATABASE_NAME = "judoscale_que_test"
 DATABASE_USERNAME = "postgres"
-ENV["DATABASE_URL"] ||= "postgres://#{DATABASE_USERNAME}:@localhost/#{DATABASE_NAME}"
+DATABASE_URL = "postgres://#{DATABASE_USERNAME}:@localhost/#{DATABASE_NAME}"
 
-ActiveRecord::Tasks::DatabaseTasks.create_all
+ActiveRecord::Tasks::DatabaseTasks.create(DATABASE_URL)
 Minitest.after_run {
-  ActiveRecord::Tasks::DatabaseTasks.drop_all
+  ActiveRecord::Tasks::DatabaseTasks.drop(DATABASE_URL)
 }
-ActiveRecord::Base.establish_connection
+ActiveRecord::Base.establish_connection(DATABASE_URL)
 
 Que.connection = ActiveRecord
 Que::Migrations.migrate!(version: Que::Migrations::CURRENT_VERSION)


### PR DESCRIPTION
Even though DJ is somewhat DB agnostic, this keeps it consistent with
Que and the sample apps by running everything with PostgreSQL.

I ran into a small issue with setting up the DB via the DATABASE_URL ENV
var, for some reason it was working with the Que test setup but not with
DJ here, it seems to be related to some load order. Instead I have moved
both to create/drop just the specific database for their respective
tests by passing it as an argument to the AR database tasks, which I
think is even safer than the previous create/drop all approach.