### PR TITLE
Remove the collection of a "default" queue across all job adapters

### DIFF
--- a/judoscale-resque/test/metrics_collector_test.rb
+++ b/judoscale-resque/test/metrics_collector_test.rb
@@ -32,8 +32,16 @@ module Judoscale
         _(metrics[1].identifier).must_equal :qd
       end
 
-      it "always collects for the default queue" do
+      it "always collects for known queues" do
         queues = []
+
+        metrics = ::Resque.stub(:queues, queues) {
+          subject.collect
+        }
+
+        _(metrics).must_be :empty?
+
+        queues = ["default"]
         size = 0
 
         metrics = ::Resque.stub(:queues, queues) {
@@ -44,19 +52,6 @@ module Judoscale
 
         _(metrics.size).must_equal 1
         _(metrics[0].queue_name).must_equal "default"
-        _(metrics[0].value).must_equal 0
-        _(metrics[0].identifier).must_equal :qd
-      end
-
-      it "always collects for known queues" do
-        queues = ["low"]
-        size = 0
-
-        ::Resque.stub(:queues, queues) {
-          ::Resque.stub(:size, size) {
-            subject.collect
-          }
-        }
 
         queues = []
 
@@ -66,8 +61,8 @@ module Judoscale
           }
         }
 
-        _(metrics.size).must_equal 2
-        _(metrics.map(&:queue_name)).must_equal %w[default low]
+        _(metrics.size).must_equal 1
+        _(metrics[0].queue_name).must_equal "default"
       end
 
       it "logs debug information for each queue being collected" do

--- a/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
@@ -33,12 +33,10 @@ module Judoscale
       logger.info log_msg
     end
 
+    # Track the known queues so we can continue reporting on queues that don't
+    # have enqueued jobs at the time of reporting.
     def queues
-      # Track the known queues so we can continue reporting on queues that don't
-      # have enqueued jobs at the time of reporting.
-      # Assume a "default" queue on all job metrics collectors so we always report *something*,
-      # even when nothing is enqueued.
-      @queues ||= Set.new(["default"])
+      @queues ||= Set.new([])
     end
 
     def queues=(new_queues)


### PR DESCRIPTION
This was a partial fix to ensure the adapters would report something for
a "known" queue every time they started, because some adapters aren't
able to keep track of previously known queues (mostly the SQL based ones
that don't keep jobs around).

The backend however is able to handle those gracefully by assuming a "0"
value if it is not getting reports of a previously reported queue, so it
doesn't really need the "default" hard-coded implementation we had here.
Plus, it'd only work for the "default", not for other custom queues.