### PR TITLE
Prevent Que adapter from collecting metrics of jobs locked for execution

### DIFF
--- a/judoscale-que/lib/judoscale/que/metrics_collector.rb
+++ b/judoscale-que/lib/judoscale/que/metrics_collector.rb
@@ -23,6 +23,11 @@ module Judoscale
           WHERE finished_at IS NULL
           AND expired_at IS NULL
           AND error_count = 0
+          AND id NOT IN (
+            SELECT (classid::bigint << 32) + objid::bigint AS id
+            FROM pg_locks
+            WHERE locktype = 'advisory'
+          )
           GROUP BY 1
         SQL
 


### PR DESCRIPTION
We need to exclude Que jobs locked for execution when looking up latency
metrics, otherwise they will inflate the latency with the time it takes
to execute those jobs, causing Que latency behavior (and thus,
autoscaling) to be different than other adapters.

References:
Issue: https://github.com/adamlogic/rails_autoscale_agent/issues/42
PR: https://github.com/adamlogic/rails_autoscale_agent/pull/43
Que job stats: https://github.com/que-rb/que/blob/620786dc70676ed1d1ad418171e12decfe42802e/lib/que/utils/introspection.rb#L8-L25

We unfortunately can't rely on their job stats introspection because
that doesn't expose the queue, it groups by job class, but the general
idea to exclude locked jobs was borrowed from that query.