### PR TITLE
Lock library supported versions and test judoscale-sidekiq with both Sidekiq 5 & 6

### DIFF
--- a/.github/workflows/judoscale-que-test.yml
+++ b/.github/workflows/judoscale-que-test.yml
@@ -15,6 +15,7 @@ jobs:
         gemfile:
           - Gemfile
           - Gemfile-activerecord-6-1
+          - Gemfile-que-2-beta
         ruby:
           - '2.6'
           - '2.7'
@@ -22,6 +23,8 @@ jobs:
           - '3.1'
         exclude:
           - gemfile: Gemfile
+            ruby: '2.6'
+          - gemfile: Gemfile-que-2-beta
             ruby: '2.6'
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps

--- a/.github/workflows/judoscale-sidekiq-test.yml
+++ b/.github/workflows/judoscale-sidekiq-test.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         gemfile:
           - Gemfile
+          - Gemfile-sidekiq-5
         ruby:
           - '2.6'
           - '2.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...main)
 
+- Enforce and test against supported versions officially across all job adapters:
+  - Sidekiq: 5, 6
+  - Resque: 2
+  - Que: 1
+  - DJ: 4
+- Prevent Que adapter from collecting metrics of jobs locked for execution. [Original issue reference](https://github.com/adamlogic/rails_autoscale_agent/issues/42) ([#85](https://github.com/judoscale/judoscale-ruby/pull/85))
+- Remove the collection of a "default" queue across all job adapters. ([#84](https://github.com/judoscale/judoscale-ruby/pull/84))
 - Make logging more consistent if it has been configured: ([#60](https://github.com/judoscale/judoscale-ruby/pull/60))
   - Without a configured log level, we'll just let the underlying logger (e.g. `Rails.logger` in the context of Rails) handle it.
   - With a configured log level, we:
     - skip if that level doesn't allow logging. (e.g. configured to INFO skips DEBUG logs by default)
     - let the underlying logger handle it if it allows the log level. (e.g. configured to INFO and logger has level INFO or DEBUG)
     - prefix our level to the message and use the underlying logger level if it doesn't allow ours, to ensure messages are logged. (e.g. configured to DEBUG and logger has level INFO, which wouldn't allow DEBUG messages)
-- Add sample app for `judoscale-sidekiq`. ([#56](https://github.com/judoscale/judoscale-ruby/pull/56))
-- Add sample app for `judoscale-rails`. ([#41](https://github.com/judoscale/judoscale-ruby/pull/41))
+- Add sample apps:
+  - `judoscale-rails` ([#41](https://github.com/judoscale/judoscale-ruby/pull/41))
+  - `judoscale-sidekiq` ([#56](https://github.com/judoscale/judoscale-ruby/pull/56))
+  - `judoscale-resque` ([#74](https://github.com/judoscale/judoscale-ruby/pull/74))
+  - `judoscale-delayed_job` ([#75](https://github.com/judoscale/judoscale-ruby/pull/75))
+  - `judoscale-que` ([#76](https://github.com/judoscale/judoscale-ruby/pull/76))
 - Split into multiple libraries/adapters: (including several internal refactorings & renamings to the core code to enable better separation and registration of the different libraries/adapters)
   - `judoscale-ruby` is the base Ruby library containing the core implementation used by all other libraries, and is responsible for running the metrics collection and reporting to Judoscale. ([#47](https://github.com/judoscale/judoscale-ruby/pull/47))
   - `judoscale-rails` integrates with Rails to initialize the reporter on app boot to send metrics to Judoscale, and register a middleware to collect web request metrics for reporting. ([#47](https://github.com/judoscale/judoscale-ruby/pull/47))

--- a/judoscale-que/Gemfile-que-2-beta
+++ b/judoscale-que/Gemfile-que-2-beta
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "judoscale-ruby", path: "../judoscale-ruby"
+gem "que", "~> 2.0.0.beta1"
+gem "activerecord"
+gem "pg"
+gem "minitest"
+gem "rake"

--- a/judoscale-que/Gemfile.lock
+++ b/judoscale-que/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
   specs:
     judoscale-que (0.1.0.alpha)
       judoscale-ruby
-      que
+      que (>= 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/judoscale-que/judoscale-que.gemspec
+++ b/judoscale-que/judoscale-que.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_dependency "judoscale-ruby"
-  spec.add_dependency "que"
+  spec.add_dependency "que", ">= 1.0"
 end

--- a/judoscale-que/test/metrics_collector_test.rb
+++ b/judoscale-que/test/metrics_collector_test.rb
@@ -8,8 +8,8 @@ module Judoscale
   describe Que::MetricsCollector do
     def enqueue(queue, run_at)
       ActiveRecord::Base.connection.insert <<~SQL
-        INSERT INTO que_jobs (job_class, queue, run_at)
-        VALUES ('TestJob', '#{queue}', '#{run_at.utc.iso8601(6)}')
+        INSERT INTO que_jobs (job_class, job_schema_version, queue, run_at)
+        VALUES ('TestJob', 1, '#{queue}', '#{run_at.utc.iso8601(6)}')
       SQL
     end
 

--- a/judoscale-sidekiq/Gemfile-sidekiq-5
+++ b/judoscale-sidekiq/Gemfile-sidekiq-5
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "judoscale-ruby", path: "../judoscale-ruby"
+gem "sidekiq", "~> 5.0"
+gem "minitest"
+gem "rake"


### PR DESCRIPTION
Version support:

- Sidekiq: 5, 6
- Resque: 2
- Que: 1 (and eventually 2)
- DJ: 4

Que was the only one that didn't have a minimum enforced version in the gemspec, I updated it here to reflect that. The others were already matching the above. I also went ahead and setup a Gemfile for v2 beta to help ensure we're covered there when they release a final version. (then we can just swap the Gemfile versions, moving v2 beta to the main one)

Sidekiq is now testing against both of those versions.