### PR TITLE
Quality of life improvements for SQL adapters & tagged logging

### DIFF
--- a/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
@@ -9,7 +9,7 @@ module Judoscale
     class MetricsCollector < Judoscale::JobMetricsCollector
       include ActiveRecordHelper
 
-      METRICS_SQL = <<~SQL
+      METRICS_SQL = ActiveRecordHelper.cleanse_sql(<<~SQL)
         SELECT COALESCE(queue, 'default'), min(run_at)
         FROM delayed_jobs
         WHERE locked_at IS NULL
@@ -17,7 +17,7 @@ module Judoscale
         GROUP BY queue
       SQL
 
-      BUSY_METRICS_SQL = <<~SQL
+      BUSY_METRICS_SQL = ActiveRecordHelper.cleanse_sql(<<~SQL)
         SELECT COALESCE(queue, 'default'), count(*)
         FROM delayed_jobs
         WHERE locked_at IS NOT NULL

--- a/judoscale-que/lib/judoscale/que/metrics_collector.rb
+++ b/judoscale-que/lib/judoscale/que/metrics_collector.rb
@@ -9,7 +9,7 @@ module Judoscale
     class MetricsCollector < Judoscale::JobMetricsCollector
       include ActiveRecordHelper
 
-      METRICS_SQL = <<~SQL
+      METRICS_SQL = ActiveRecordHelper.cleanse_sql(<<~SQL)
         SELECT queue, min(run_at)
         FROM que_jobs
         WHERE finished_at IS NULL

--- a/judoscale-ruby/lib/judoscale/job_metrics_collector/active_record_helper.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector/active_record_helper.rb
@@ -1,10 +1,15 @@
+# frozen_string_literal: true
+
 module Judoscale
   class JobMetricsCollector
     module ActiveRecordHelper
       # Cleanup any whitespace characters (including new lines) from the SQL for simpler logging.
       # Reference: ActiveSupport's `squish!` method. https://api.rubyonrails.org/classes/String.html#method-i-squish
       def self.cleanse_sql(sql)
-        sql.gsub(/[[:space:]]+/, " ").strip
+        sql = sql.dup
+        sql.gsub!(/[[:space:]]+/, " ")
+        sql.strip!
+        sql
       end
 
       private

--- a/judoscale-ruby/lib/judoscale/job_metrics_collector/active_record_helper.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector/active_record_helper.rb
@@ -11,7 +11,15 @@ module Judoscale
 
       def select_rows_silently(sql)
         if Config.instance.log_level && ::ActiveRecord::Base.logger.respond_to?(:silence)
-          ::ActiveRecord::Base.logger.silence(Config.instance.log_level) { select_rows(sql) }
+          ::ActiveRecord::Base.logger.silence(Config.instance.log_level) { select_rows_tagged(sql) }
+        else
+          select_rows_tagged(sql)
+        end
+      end
+
+      def select_rows_tagged(sql)
+        if ActiveRecord::Base.logger.respond_to?(:tagged)
+          ActiveRecord::Base.logger.tagged(Judoscale::LoggerProxy::TAG) { select_rows(sql) }
         else
           select_rows(sql)
         end

--- a/judoscale-ruby/lib/judoscale/job_metrics_collector/active_record_helper.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector/active_record_helper.rb
@@ -1,6 +1,12 @@
 module Judoscale
   class JobMetricsCollector
     module ActiveRecordHelper
+      # Cleanup any whitespace characters (including new lines) from the SQL for simpler logging.
+      # Reference: ActiveSupport's `squish!` method. https://api.rubyonrails.org/classes/String.html#method-i-squish
+      def self.cleanse_sql(sql)
+        sql.gsub(/[[:space:]]+/, " ").strip
+      end
+
       private
 
       def select_rows_silently(sql)

--- a/judoscale-ruby/lib/judoscale/logger.rb
+++ b/judoscale-ruby/lib/judoscale/logger.rb
@@ -11,8 +11,7 @@ module Judoscale
   end
 
   class LoggerProxy < Struct.new(:logger, :log_level)
-    TAG = "[Judoscale]"
-    DEBUG_TAG = " [DEBUG]"
+    TAG = "Judoscale"
 
     %w[ERROR WARN INFO DEBUG].each do |severity_name|
       severity_level = ::Logger::Severity.const_get(severity_name)
@@ -33,8 +32,9 @@ module Judoscale
     private
 
     def tag(msgs, tag_level: nil)
-      tag_level = " [#{tag_level}]" if tag_level
-      msgs.map { |msg| "#{TAG}#{tag_level} #{msg}" }.join("\n")
+      tag = +"[#{TAG}]"
+      tag << " [#{tag_level}]" if tag_level
+      msgs.map { |msg| "#{tag} #{msg}" }.join("\n")
     end
   end
 end


### PR DESCRIPTION
I wanted to extract the SQL queries from the bulk of the methods into constants, and while testing that I noticed they can be quite noisy on the logs, as AR emits the SQL as provided (with new lines, etc.), and that they weren't prefixed with `[Judoscale]` like all other logging emitted by the libs, so I went ahead and added a cleanse function (which is basically [Active Support's `squish` method](https://api.rubyonrails.org/classes/String.html#method-i-squish)) and the [tagged logging via the AR::Base logger](https://api.rubyonrails.org/classes/ActiveSupport/TaggedLogging.html#method-i-tagged) (as long as it supports it).

### Samples

**Delayed Job**

```sql
7:13:47 PM rails.1 |     (0.2ms)  SELECT COALESCE(queue, 'default'), min(run_at)
7:13:47 PM rails.1 |  FROM delayed_jobs
7:13:47 PM rails.1 |  WHERE locked_at IS NULL
7:13:47 PM rails.1 |  AND failed_at IS NULL
7:13:47 PM rails.1 |  GROUP BY queue
7:13:47 PM rails.1 |
7:13:47 PM rails.1 |  [Judoscale] Reporting 0 metrics
```

```sql
7:14:37 PM rails.1 |  [Judoscale]    (4.5ms)  SELECT queue, min(run_at) FROM que_jobs WHERE finished_at IS NULL AND expired_at IS NULL AND error_count = 0 AND id NOT IN ( SELECT (classid::bigint << 32) + objid::bigint AS id FROM pg_locks WHERE locktype = 'advisory' ) GROUP BY 1
7:14:37 PM rails.1 |  [Judoscale] Reporting 0 metrics
```

**Que**

```sql
7:13:23 PM rails.1 |     (1.7ms)  SELECT queue, min(run_at)
7:13:23 PM rails.1 |  FROM que_jobs
7:13:23 PM rails.1 |  WHERE finished_at IS NULL
7:13:23 PM rails.1 |  AND expired_at IS NULL
7:13:23 PM rails.1 |  AND error_count = 0
7:13:23 PM rails.1 |  AND id NOT IN (
7:13:23 PM rails.1 |    SELECT (classid::bigint << 32) + objid::bigint AS id
7:13:23 PM rails.1 |    FROM pg_locks
7:13:23 PM rails.1 |    WHERE locktype = 'advisory'
7:13:23 PM rails.1 |  )
7:13:23 PM rails.1 |  GROUP BY 1
7:13:23 PM rails.1 |
7:13:23 PM rails.1 |  [Judoscale] Reporting 0 metrics
```

```sql
7:14:18 PM rails.1 |  [Judoscale]    (1.3ms)  SELECT COALESCE(queue, 'default'), min(run_at) FROM delayed_jobs WHERE locked_at IS NULL AND failed_at IS NULL GROUP BY queue
7:14:18 PM rails.1 |  [Judoscale] Reporting 0 metrics
```