### PR TITLE
Use the job adapter identifier to log metrics collection

### DIFF
--- a/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
@@ -57,7 +57,7 @@ module Judoscale
           end
         end
 
-        log_collection(:delayed_job, metrics)
+        log_collection(metrics)
         metrics
       end
     end

--- a/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
@@ -57,7 +57,7 @@ module Judoscale
           end
         end
 
-        log_collection(:dj, metrics)
+        log_collection(:delayed_job, metrics)
         metrics
       end
     end

--- a/judoscale-delayed_job/test/metrics_collector_test.rb
+++ b/judoscale-delayed_job/test/metrics_collector_test.rb
@@ -91,8 +91,8 @@ module Judoscale
 
           subject.collect
 
-          _(log_string).must_match %r{dj-qt.default=\d+ms}
-          _(log_string).wont_match %r{dj-busy}
+          _(log_string).must_match %r{delayed_job-qt.default=\d+ms}
+          _(log_string).wont_match %r{delayed_job-busy}
         end
       end
 
@@ -125,7 +125,7 @@ module Judoscale
 
             subject.collect
 
-            _(log_string).must_match %r{dj-qt.default=.+ dj-busy.default=1}
+            _(log_string).must_match %r{delayed_job-qt.default=.+ delayed_job-busy.default=1}
           end
         end
       end

--- a/judoscale-que/lib/judoscale/que/metrics_collector.rb
+++ b/judoscale-que/lib/judoscale/que/metrics_collector.rb
@@ -43,7 +43,7 @@ module Judoscale
           metrics.push Metric.new(:qt, latency_ms, t, queue)
         end
 
-        log_collection(:que, metrics)
+        log_collection(metrics)
         metrics
       end
     end

--- a/judoscale-resque/lib/judoscale/resque/metrics_collector.rb
+++ b/judoscale-resque/lib/judoscale/resque/metrics_collector.rb
@@ -23,7 +23,7 @@ module Judoscale
           metrics.push Metric.new(:qd, depth, Time.now, queue)
         end
 
-        log_collection(:resque, metrics)
+        log_collection(metrics)
         metrics
       end
     end

--- a/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
@@ -86,11 +86,12 @@ module Judoscale
       end
     end
 
-    # Sample log line for each collection, assuming `sidekiq` as the identifier:
+    # Sample log line for each collection, assuming `sidekiq` as the adapter identifier:
     #   `sidekiq-qt.default=10ms sidekiq-qd.default=3 sidekiq-busy.default=1`
-    def log_collection(identifier, metrics)
+    def log_collection(metrics)
       return if metrics.empty?
 
+      identifier = self.class.adapter_identifier
       messages = metrics.map { |metric|
         "#{identifier}-#{metric.identifier}.#{metric.queue_name}=#{metric.value}#{"ms" if metric.identifier == :qt}"
       }

--- a/judoscale-sidekiq/lib/judoscale/sidekiq/metrics_collector.rb
+++ b/judoscale-sidekiq/lib/judoscale/sidekiq/metrics_collector.rb
@@ -39,7 +39,7 @@ module Judoscale
           end
         end
 
-        log_collection(:sidekiq, metrics)
+        log_collection(metrics)
         metrics
       end
     end


### PR DESCRIPTION
Unify job adapter logging by using the same identifier from the config, so they can all consistently use the same "constant" identifier on all places we need to refer to them.

This required changing the Delayed Job adapter to use `delayed_job` instead of the shorter `dj` version in the longs.