### PR TITLE
Add busy metrics to Que job adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v1.0.0.rc1...main)
 
+- Add busy job tracking support for Que: ([#97](https://github.com/judoscale/judoscale-ruby/pull/97))
+
 ## [1.0.0.rc1](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...v1.0.0.rc1)
 
 - Add busy job tracking support for Resque: ([#92](https://github.com/judoscale/judoscale-ruby/pull/92))

--- a/sample-apps/que-sample/config/initializers/judoscale.rb
+++ b/sample-apps/que-sample/config/initializers/judoscale.rb
@@ -1,4 +1,7 @@
 Judoscale.configure do |config|
   # Open https://judoscale-adapter-mock.requestcatcher.com in a browser to monitor requests
   config.api_base_url = "https://judoscale-adapter-mock.requestcatcher.com"
+
+  # Enable busy jobs tracking for testing with the sample app.
+  config.que.track_busy_jobs = true
 end


### PR DESCRIPTION
Use a similar query from Que's introspection module [1] to look for
locked jobs and determine how many are currently busy/working, so we can
report back to Judoscale via the API.

I decided to ignore the other filters we have on the main query for this
one, since it appears Que only really cares about the locked jobs to
know how many are "working" (our concept of "busy"), so it seemed more
inline with them, but this might change in the future to be more inline
with our other metrics query.

[1] https://github.com/que-rb/que/blob/edb907e597b2e36b673a197901481a65d62507e1/lib/que/utils/introspection.rb#L7-L25

### Samples

<img width="602" alt="Screen Shot 2022-04-18 at 19 12 48" src="https://user-images.githubusercontent.com/26328/163885893-6077341e-acf3-4d96-9dbd-4ca603987a82.png">

<img width="575" alt="Screen Shot 2022-04-18 at 19 12 52" src="https://user-images.githubusercontent.com/26328/163885897-fb531bbd-9205-41c6-ad71-116aa9c5cfa0.png">

