### PR TITLE
Refactor config setup to decrease hidden dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/judoscale/judoscale-ruby/compare/v1.0.0.rc1...main)
 
+- Refactor how the config is exposed and accessed from job adapters / collectors to simplify and remove some indirection. ([#99](https://github.com/judoscale/judoscale-ruby/pull/99))
 - Add busy job tracking support for Que: ([#97](https://github.com/judoscale/judoscale-ruby/pull/97))
 
 ## [1.0.0.rc1](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...v1.0.0.rc1)

--- a/judoscale-delayed_job/lib/judoscale/delayed_job.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job.rb
@@ -11,4 +11,4 @@ Judoscale.add_adapter :"judoscale-delayed_job", {
   framework_version: Gem.loaded_specs["delayed_job_active_record"].version.to_s # DJ doesn't have a `VERSION` constant
 }, metrics_collector: Judoscale::DelayedJob::MetricsCollector
 
-Judoscale::Config.add_adapter_config :delayed_job, Judoscale::Config::JobAdapterConfig
+Judoscale::Config.add_adapter_config Judoscale::Config::JobAdapterConfig.new(:delayed_job)

--- a/judoscale-delayed_job/lib/judoscale/delayed_job.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job.rb
@@ -6,8 +6,10 @@ require "judoscale/delayed_job/version"
 require "judoscale/delayed_job/metrics_collector"
 require "delayed_job_active_record"
 
-Judoscale.add_adapter :"judoscale-delayed_job", {
-  adapter_version: Judoscale::DelayedJob::VERSION,
-  framework_version: Gem.loaded_specs["delayed_job_active_record"].version.to_s # DJ doesn't have a `VERSION` constant
-}, metrics_collector: Judoscale::DelayedJob::MetricsCollector,
+Judoscale.add_adapter :"judoscale-delayed_job",
+  {
+    adapter_version: Judoscale::DelayedJob::VERSION,
+    framework_version: Gem.loaded_specs["delayed_job_active_record"].version.to_s # DJ doesn't have a `VERSION` constant
+  },
+  metrics_collector: Judoscale::DelayedJob::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:delayed_job)

--- a/judoscale-delayed_job/lib/judoscale/delayed_job.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job.rb
@@ -9,6 +9,5 @@ require "delayed_job_active_record"
 Judoscale.add_adapter :"judoscale-delayed_job", {
   adapter_version: Judoscale::DelayedJob::VERSION,
   framework_version: Gem.loaded_specs["delayed_job_active_record"].version.to_s # DJ doesn't have a `VERSION` constant
-}, metrics_collector: Judoscale::DelayedJob::MetricsCollector
-
-Judoscale::Config.expose_config Judoscale::Config::JobAdapterConfig.new(:delayed_job)
+}, metrics_collector: Judoscale::DelayedJob::MetricsCollector,
+  expose_config: Judoscale::Config::JobAdapterConfig.new(:delayed_job)

--- a/judoscale-delayed_job/lib/judoscale/delayed_job.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job.rb
@@ -11,4 +11,4 @@ Judoscale.add_adapter :"judoscale-delayed_job", {
   framework_version: Gem.loaded_specs["delayed_job_active_record"].version.to_s # DJ doesn't have a `VERSION` constant
 }, metrics_collector: Judoscale::DelayedJob::MetricsCollector
 
-Judoscale::Config.add_adapter_config Judoscale::Config::JobAdapterConfig.new(:delayed_job)
+Judoscale::Config.expose_config Judoscale::Config::JobAdapterConfig.new(:delayed_job)

--- a/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
@@ -26,8 +26,8 @@ module Judoscale
         GROUP BY 1
       SQL
 
-      def self.adapter_identifier
-        :delayed_job
+      def self.adapter_config
+        Judoscale::Config.instance.delayed_job
       end
 
       def collect

--- a/judoscale-que/lib/judoscale/que.rb
+++ b/judoscale-que/lib/judoscale/que.rb
@@ -11,4 +11,4 @@ Judoscale.add_adapter :"judoscale-que", {
   framework_version: ::Que::VERSION
 }, metrics_collector: Judoscale::Que::MetricsCollector
 
-Judoscale::Config.add_adapter_config :que, Judoscale::Config::JobAdapterConfig
+Judoscale::Config.add_adapter_config Judoscale::Config::JobAdapterConfig.new(:que)

--- a/judoscale-que/lib/judoscale/que.rb
+++ b/judoscale-que/lib/judoscale/que.rb
@@ -9,6 +9,5 @@ require "que"
 Judoscale.add_adapter :"judoscale-que", {
   adapter_version: Judoscale::Que::VERSION,
   framework_version: ::Que::VERSION
-}, metrics_collector: Judoscale::Que::MetricsCollector
-
-Judoscale::Config.expose_config Judoscale::Config::JobAdapterConfig.new(:que)
+}, metrics_collector: Judoscale::Que::MetricsCollector,
+  expose_config: Judoscale::Config::JobAdapterConfig.new(:que)

--- a/judoscale-que/lib/judoscale/que.rb
+++ b/judoscale-que/lib/judoscale/que.rb
@@ -11,4 +11,4 @@ Judoscale.add_adapter :"judoscale-que", {
   framework_version: ::Que::VERSION
 }, metrics_collector: Judoscale::Que::MetricsCollector
 
-Judoscale::Config.add_adapter_config Judoscale::Config::JobAdapterConfig.new(:que)
+Judoscale::Config.expose_config Judoscale::Config::JobAdapterConfig.new(:que)

--- a/judoscale-que/lib/judoscale/que.rb
+++ b/judoscale-que/lib/judoscale/que.rb
@@ -6,8 +6,10 @@ require "judoscale/que/version"
 require "judoscale/que/metrics_collector"
 require "que"
 
-Judoscale.add_adapter :"judoscale-que", {
-  adapter_version: Judoscale::Que::VERSION,
-  framework_version: ::Que::VERSION
-}, metrics_collector: Judoscale::Que::MetricsCollector,
+Judoscale.add_adapter :"judoscale-que",
+  {
+    adapter_version: Judoscale::Que::VERSION,
+    framework_version: ::Que::VERSION
+  },
+  metrics_collector: Judoscale::Que::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:que)

--- a/judoscale-que/lib/judoscale/que/metrics_collector.rb
+++ b/judoscale-que/lib/judoscale/que/metrics_collector.rb
@@ -34,8 +34,8 @@ module Judoscale
         GROUP BY 1
       SQL
 
-      def self.adapter_identifier
-        :que
+      def self.adapter_config
+        Judoscale::Config.instance.que
       end
 
       def collect

--- a/judoscale-resque/lib/judoscale/resque.rb
+++ b/judoscale-resque/lib/judoscale/resque.rb
@@ -11,4 +11,4 @@ Judoscale.add_adapter :"judoscale-resque", {
   framework_version: ::Resque::VERSION
 }, metrics_collector: Judoscale::Resque::MetricsCollector
 
-Judoscale::Config.add_adapter_config :resque, Judoscale::Config::JobAdapterConfig
+Judoscale::Config.add_adapter_config Judoscale::Config::JobAdapterConfig.new(:resque)

--- a/judoscale-resque/lib/judoscale/resque.rb
+++ b/judoscale-resque/lib/judoscale/resque.rb
@@ -6,8 +6,10 @@ require "judoscale/resque/version"
 require "judoscale/resque/metrics_collector"
 require "resque"
 
-Judoscale.add_adapter :"judoscale-resque", {
-  adapter_version: Judoscale::Resque::VERSION,
-  framework_version: ::Resque::VERSION
-}, metrics_collector: Judoscale::Resque::MetricsCollector,
+Judoscale.add_adapter :"judoscale-resque",
+  {
+    adapter_version: Judoscale::Resque::VERSION,
+    framework_version: ::Resque::VERSION
+  },
+  metrics_collector: Judoscale::Resque::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:resque)

--- a/judoscale-resque/lib/judoscale/resque.rb
+++ b/judoscale-resque/lib/judoscale/resque.rb
@@ -11,4 +11,4 @@ Judoscale.add_adapter :"judoscale-resque", {
   framework_version: ::Resque::VERSION
 }, metrics_collector: Judoscale::Resque::MetricsCollector
 
-Judoscale::Config.add_adapter_config Judoscale::Config::JobAdapterConfig.new(:resque)
+Judoscale::Config.expose_config Judoscale::Config::JobAdapterConfig.new(:resque)

--- a/judoscale-resque/lib/judoscale/resque.rb
+++ b/judoscale-resque/lib/judoscale/resque.rb
@@ -9,6 +9,5 @@ require "resque"
 Judoscale.add_adapter :"judoscale-resque", {
   adapter_version: Judoscale::Resque::VERSION,
   framework_version: ::Resque::VERSION
-}, metrics_collector: Judoscale::Resque::MetricsCollector
-
-Judoscale::Config.expose_config Judoscale::Config::JobAdapterConfig.new(:resque)
+}, metrics_collector: Judoscale::Resque::MetricsCollector,
+  expose_config: Judoscale::Config::JobAdapterConfig.new(:resque)

--- a/judoscale-resque/lib/judoscale/resque/metrics_collector.rb
+++ b/judoscale-resque/lib/judoscale/resque/metrics_collector.rb
@@ -6,8 +6,8 @@ require "judoscale/metric"
 module Judoscale
   module Resque
     class MetricsCollector < Judoscale::JobMetricsCollector
-      def self.adapter_identifier
-        :resque
+      def self.adapter_config
+        Judoscale::Config.instance.resque
       end
 
       def collect

--- a/judoscale-ruby/lib/judoscale-ruby.rb
+++ b/judoscale-ruby/lib/judoscale-ruby.rb
@@ -26,7 +26,8 @@ module Judoscale
     end
   end
 
-  def self.add_adapter(identifier, adapter_info, metrics_collector: nil)
+  def self.add_adapter(identifier, adapter_info, metrics_collector: nil, expose_config: nil)
+    Config.expose_adapter_config(expose_config) if expose_config
     @adapters << Adapter.new(identifier, adapter_info, metrics_collector)
   end
 

--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -54,7 +54,7 @@ module Judoscale
       attr_reader :adapter_configs
     end
 
-    def self.expose_config(config_instance)
+    def self.expose_adapter_config(config_instance)
       @adapter_configs[config_instance.identifier] = config_instance
 
       define_method(config_instance.identifier) do

--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -39,10 +39,12 @@ module Judoscale
 
       def as_json
         {
-          max_queues: max_queues,
-          queues: queues,
-          queue_filter: queue_filter != DEFAULT_QUEUE_FILTER,
-          track_busy_jobs: track_busy_jobs
+          identifier => {
+            max_queues: max_queues,
+            queues: queues,
+            queue_filter: queue_filter != DEFAULT_QUEUE_FILTER,
+            track_busy_jobs: track_busy_jobs
+          }
         }
       end
     end
@@ -90,9 +92,7 @@ module Judoscale
     end
 
     def as_json
-      adapter_configs_json = self.class.adapter_configs.each_with_object({}) do |config_instance, hash|
-        hash[config_instance.identifier] = config_instance.as_json
-      end
+      adapter_configs_json = self.class.adapter_configs.reduce({}) { |hash, config| hash.merge!(config.as_json) }
 
       {
         log_level: log_level,

--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -49,13 +49,13 @@ module Judoscale
 
     include Singleton
 
-    @adapter_configs = {}
+    @adapter_configs = []
     class << self
       attr_reader :adapter_configs
     end
 
     def self.expose_adapter_config(config_instance)
-      @adapter_configs[config_instance.identifier] = config_instance
+      adapter_configs << config_instance
 
       define_method(config_instance.identifier) do
         config_instance
@@ -78,7 +78,7 @@ module Judoscale
       self.log_level = ENV["JUDOSCALE_LOG_LEVEL"]
       @logger = ::Logger.new($stdout)
 
-      self.class.adapter_configs.each_value(&:reset)
+      self.class.adapter_configs.each(&:reset)
     end
 
     def dyno=(dyno_string)
@@ -90,8 +90,8 @@ module Judoscale
     end
 
     def as_json
-      adapter_configs_json = self.class.adapter_configs.each_with_object({}) do |(identifier, config_instance), hash|
-        hash[identifier] = config_instance.as_json
+      adapter_configs_json = self.class.adapter_configs.each_with_object({}) do |config_instance, hash|
+        hash[config_instance.identifier] = config_instance.as_json
       end
 
       {

--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -54,7 +54,7 @@ module Judoscale
       attr_reader :adapter_configs
     end
 
-    def self.add_adapter_config(config_instance)
+    def self.expose_config(config_instance)
       @adapter_configs[config_instance.identifier] = config_instance
 
       define_method(config_instance.identifier) do

--- a/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
@@ -18,11 +18,11 @@ module Judoscale
     end
 
     def self.adapter_identifier
-      raise "Implement `self.adapter_identifier` in individual job metrics collectors."
+      adapter_config.identifier
     end
 
     def self.adapter_config
-      Config.instance.public_send(adapter_identifier)
+      raise "Implement `self.adapter_config` in individual job metrics collectors."
     end
 
     def initialize

--- a/judoscale-ruby/lib/judoscale/report.rb
+++ b/judoscale-ruby/lib/judoscale/report.rb
@@ -15,9 +15,7 @@ module Judoscale
         dyno: config.dyno,
         pid: Process.pid,
         config: config.as_json,
-        adapters: adapters.each_with_object({}) { |adapter, hash|
-          hash.merge!(adapter.as_json)
-        },
+        adapters: adapters.reduce({}) { |hash, adapter| hash.merge!(adapter.as_json) },
         metrics: metrics.map { |metric|
           [
             metric.time.to_i,

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -15,9 +15,7 @@ module Judoscale
         _(config.max_request_size_bytes).must_equal 100_000
         _(config.report_interval_seconds).must_equal 10
 
-        enabled_adapter_configs = Config.adapter_configs.keys.select { |identifier|
-          config.public_send(identifier).enabled
-        }
+        enabled_adapter_configs = Config.adapter_configs.select(&:enabled).map(&:identifier)
         _(enabled_adapter_configs).must_equal %i[test_job_config]
 
         enabled_adapter_configs.each do |adapter_name|
@@ -70,9 +68,7 @@ module Judoscale
       _(config.test_job_config.max_queues).must_equal 100
       _(config.test_job_config.track_busy_jobs).must_equal true
 
-      enabled_adapter_configs = Config.adapter_configs.keys.select { |identifier|
-        config.public_send(identifier).enabled
-      }
+      enabled_adapter_configs = Config.adapter_configs.select(&:enabled).map(&:identifier)
       _(enabled_adapter_configs).must_be :empty?
     end
 

--- a/judoscale-ruby/test/test_helper.rb
+++ b/judoscale-ruby/test/test_helper.rb
@@ -13,8 +13,8 @@ require "judoscale/web_metrics_collector"
 module Judoscale
   module Test
     class TestJobMetricsCollector < Judoscale::JobMetricsCollector
-      def self.adapter_identifier
-        :test_job_config
+      def self.adapter_config
+        Judoscale::Config.instance.test_job_config
       end
 
       def collect

--- a/judoscale-ruby/test/test_helper.rb
+++ b/judoscale-ruby/test/test_helper.rb
@@ -31,7 +31,7 @@ module Judoscale
 
   add_adapter :test_web, {}, metrics_collector: Test::TestWebMetricsCollector
   add_adapter :test_job, {}, metrics_collector: Test::TestJobMetricsCollector
-  Config.add_adapter_config Config::JobAdapterConfig.new(:test_job_config)
+  Config.expose_config Config::JobAdapterConfig.new(:test_job_config)
 end
 
 Dir[File.expand_path("./support/*.rb", __dir__)].sort.each { |file| require file }

--- a/judoscale-ruby/test/test_helper.rb
+++ b/judoscale-ruby/test/test_helper.rb
@@ -30,8 +30,8 @@ module Judoscale
   end
 
   add_adapter :test_web, {}, metrics_collector: Test::TestWebMetricsCollector
-  add_adapter :test_job, {}, metrics_collector: Test::TestJobMetricsCollector
-  Config.expose_config Config::JobAdapterConfig.new(:test_job_config)
+  add_adapter :test_job, {}, metrics_collector: Test::TestJobMetricsCollector,
+    expose_config: Config::JobAdapterConfig.new(:test_job_config)
 end
 
 Dir[File.expand_path("./support/*.rb", __dir__)].sort.each { |file| require file }

--- a/judoscale-ruby/test/test_helper.rb
+++ b/judoscale-ruby/test/test_helper.rb
@@ -31,7 +31,7 @@ module Judoscale
 
   add_adapter :test_web, {}, metrics_collector: Test::TestWebMetricsCollector
   add_adapter :test_job, {}, metrics_collector: Test::TestJobMetricsCollector
-  Config.add_adapter_config :test_job_config, Config::JobAdapterConfig
+  Config.add_adapter_config Config::JobAdapterConfig.new(:test_job_config)
 end
 
 Dir[File.expand_path("./support/*.rb", __dir__)].sort.each { |file| require file }

--- a/judoscale-sidekiq/lib/judoscale/sidekiq.rb
+++ b/judoscale-sidekiq/lib/judoscale/sidekiq.rb
@@ -6,8 +6,10 @@ require "judoscale/sidekiq/version"
 require "judoscale/sidekiq/metrics_collector"
 require "sidekiq/api"
 
-Judoscale.add_adapter :"judoscale-sidekiq", {
-  adapter_version: Judoscale::Sidekiq::VERSION,
-  framework_version: ::Sidekiq::VERSION
-}, metrics_collector: Judoscale::Sidekiq::MetricsCollector,
+Judoscale.add_adapter :"judoscale-sidekiq",
+  {
+    adapter_version: Judoscale::Sidekiq::VERSION,
+    framework_version: ::Sidekiq::VERSION
+  },
+  metrics_collector: Judoscale::Sidekiq::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:sidekiq)

--- a/judoscale-sidekiq/lib/judoscale/sidekiq.rb
+++ b/judoscale-sidekiq/lib/judoscale/sidekiq.rb
@@ -9,6 +9,5 @@ require "sidekiq/api"
 Judoscale.add_adapter :"judoscale-sidekiq", {
   adapter_version: Judoscale::Sidekiq::VERSION,
   framework_version: ::Sidekiq::VERSION
-}, metrics_collector: Judoscale::Sidekiq::MetricsCollector
-
-Judoscale::Config.expose_config Judoscale::Config::JobAdapterConfig.new(:sidekiq)
+}, metrics_collector: Judoscale::Sidekiq::MetricsCollector,
+  expose_config: Judoscale::Config::JobAdapterConfig.new(:sidekiq)

--- a/judoscale-sidekiq/lib/judoscale/sidekiq.rb
+++ b/judoscale-sidekiq/lib/judoscale/sidekiq.rb
@@ -11,4 +11,4 @@ Judoscale.add_adapter :"judoscale-sidekiq", {
   framework_version: ::Sidekiq::VERSION
 }, metrics_collector: Judoscale::Sidekiq::MetricsCollector
 
-Judoscale::Config.add_adapter_config :sidekiq, Judoscale::Config::JobAdapterConfig
+Judoscale::Config.add_adapter_config Judoscale::Config::JobAdapterConfig.new(:sidekiq)

--- a/judoscale-sidekiq/lib/judoscale/sidekiq.rb
+++ b/judoscale-sidekiq/lib/judoscale/sidekiq.rb
@@ -11,4 +11,4 @@ Judoscale.add_adapter :"judoscale-sidekiq", {
   framework_version: ::Sidekiq::VERSION
 }, metrics_collector: Judoscale::Sidekiq::MetricsCollector
 
-Judoscale::Config.add_adapter_config Judoscale::Config::JobAdapterConfig.new(:sidekiq)
+Judoscale::Config.expose_config Judoscale::Config::JobAdapterConfig.new(:sidekiq)

--- a/judoscale-sidekiq/lib/judoscale/sidekiq/metrics_collector.rb
+++ b/judoscale-sidekiq/lib/judoscale/sidekiq/metrics_collector.rb
@@ -6,8 +6,8 @@ require "judoscale/metric"
 module Judoscale
   module Sidekiq
     class MetricsCollector < Judoscale::JobMetricsCollector
-      def self.adapter_identifier
-        :sidekiq
+      def self.adapter_config
+        Judoscale::Config.instance.sidekiq
       end
 
       def collect


### PR DESCRIPTION
Expose configs as object instances instead of classes that are handled by the Config itself, and do it as part of adding the adapters instead of a separate call through the Config.instance itself.

Move from implementing `adapter_identifier` on the individual job adapter metric collectors to implementing `adapter_config`, which access the config directly and has now a way to expose the identifier it was initialized with. This makes it clearer that the config is what the metric collector is mostly interested in, and removes some of the previous indirection based on the identifier alone to fetch the config.