### PR TITLE
Add latency suppor to Resque via an extension / plugin / monkey-patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor how the config is exposed and accessed from job adapters / collectors to simplify and remove some indirection. ([#99](https://github.com/judoscale/judoscale-ruby/pull/99))
 - Add busy job tracking support for Que: ([#97](https://github.com/judoscale/judoscale-ruby/pull/97))
+- Add queue latency support to Resque via an extension, since it doesn't support it natively. ([#100](https://github.com/judoscale/judoscale-ruby/pull/100))
 
 ## [1.0.0.rc1](https://github.com/judoscale/judoscale-ruby/compare/v0.10.2...v1.0.0.rc1)
 

--- a/judoscale-resque/lib/judoscale/resque.rb
+++ b/judoscale-resque/lib/judoscale/resque.rb
@@ -5,6 +5,7 @@ require "judoscale/config"
 require "judoscale/resque/version"
 require "judoscale/resque/metrics_collector"
 require "resque"
+require "judoscale/resque/latency_extension"
 
 Judoscale.add_adapter :"judoscale-resque",
   {

--- a/judoscale-resque/lib/judoscale/resque/latency_extension.rb
+++ b/judoscale-resque/lib/judoscale/resque/latency_extension.rb
@@ -1,0 +1,23 @@
+module Judoscale
+  module Resque
+    module LatencyExtension
+      # Store the time when jobs are pushed to the queue in order to calculate latency.
+      def push(queue, item)
+        item["timestamp"] = Time.now.utc.to_f
+        super
+      end
+
+      # Calculate latency for the given queue using the stored timestamp of the oldest item in the queue.
+      def latency(queue)
+        if (item = peek(queue))
+          timestamp = item["timestamp"]
+          timestamp ? Time.now.utc.to_f - timestamp.to_f : 0.0
+        else
+          0.0
+        end
+      end
+    end
+  end
+end
+
+::Resque.extend(Judoscale::Resque::LatencyExtension)

--- a/judoscale-resque/lib/judoscale/resque/metrics_collector.rb
+++ b/judoscale-resque/lib/judoscale/resque/metrics_collector.rb
@@ -29,7 +29,10 @@ module Judoscale
         queues.each do |queue|
           next if queue.nil? || queue.empty?
           depth = ::Resque.size(queue)
+          latency = (::Resque.latency(queue) * 1000).ceil
+
           metrics.push Metric.new(:qd, depth, Time.now, queue)
+          metrics.push Metric.new(:qt, latency, Time.now, queue)
 
           if track_busy_jobs?
             busy_count = busy_counts[queue]

--- a/judoscale-resque/test/latency_extension_test.rb
+++ b/judoscale-resque/test/latency_extension_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "judoscale/resque/latency_extension"
+
+module Judoscale
+  class RedisStub
+    attr_reader :hash
+
+    def initialize
+      @hash = Hash.new { |h, k| h[k] = [] }
+    end
+
+    def sadd(key, *values)
+      hash[key].concat(values)
+    end
+    alias_method :rpush, :sadd
+
+    def lindex(key, index)
+      hash[key][index]
+    end
+
+    def lpop(key)
+      hash[key].shift
+    end
+
+    def pipelined
+      yield
+    end
+  end
+
+  class SampleJob
+    def self.perform
+    end
+  end
+
+  describe Resque::LatencyExtension do
+    before {
+      @original_redis = ::Resque.redis
+      @redis_stub = RedisStub.new
+      ::Resque.redis = @redis_stub
+    }
+    after {
+      ::Resque.redis = @original_redis
+    }
+
+    it "includes a timestamp value with each job enqueued, used to calculate latency" do
+      freeze_time do
+        ::Resque.enqueue_to "default", SampleJob
+
+        item = ::Resque.pop("default")
+        _(item).must_equal({"class" => "Judoscale::SampleJob", "args" => [], "timestamp" => Time.now.utc.to_f})
+      end
+    end
+
+    it "calculates latency based on the oldest item in the queue" do
+      now = Time.now.utc
+
+      [now, now + 12, now + 18].each { |enqueue_time|
+        freeze_time(enqueue_time) { ::Resque.enqueue_to "default", SampleJob }
+      }
+
+      freeze_time now + 30 do
+        latency = ::Resque.latency("default")
+        _(latency).must_be_within_delta 30.0, 0.005
+      end
+
+      freeze_time now + 55.5 do
+        latency = ::Resque.latency("default")
+        _(latency).must_be_within_delta 55.5, 0.005
+      end
+
+      # Removing the oldest item to verify it uses the second enqueued item to calculate latency.
+      ::Resque.pop("default")
+
+      freeze_time now + 60 do
+        latency = ::Resque.latency("default")
+        _(latency).must_be_within_delta 48.0, 0.005
+      end
+    end
+
+    it "calculates 0 latency for previously enqueued items that have no timestamp" do
+      ::Resque.enqueue_to "default", SampleJob
+
+      @redis_stub.hash.fetch("resque:queue:default").map! { |item|
+        item = ::Resque.decode(item)
+        item.delete("timestamp")
+        ::Resque.encode(item)
+      }
+
+      freeze_time Time.now.utc + 60 do
+        latency = ::Resque.latency("default")
+        _(latency).must_equal 0.0
+      end
+    end
+
+    it "calculates 0 latency when there are no items in the queue" do
+      latency = ::Resque.latency("default")
+      _(latency).must_equal 0.0
+    end
+  end
+end

--- a/sample-apps/resque-sample/app/controllers/jobs_controller.rb
+++ b/sample-apps/resque-sample/app/controllers/jobs_controller.rb
@@ -4,7 +4,7 @@ class JobsController < ApplicationController
   def index
     @available_queues = QUEUES.dup
     @queues = ::Resque.queues.sort_by { |q, _| @available_queues.index(q) }.each_with_object({}) do |queue, hash|
-      hash[queue] = Resque.size(queue)
+      hash[queue] = { size: Resque.size(queue), latency: Resque.latency(queue) }
     end
   end
 

--- a/sample-apps/resque-sample/app/views/jobs/index.html.erb
+++ b/sample-apps/resque-sample/app/views/jobs/index.html.erb
@@ -17,8 +17,8 @@
 
 <% if @queues.any? %>
   <ul>
-    <% @queues.each do |name, size| %>
-      <li><%= name %>: <%= size %></li>
+    <% @queues.each do |name, stats| %>
+      <li><%= name %>: <%= stats.map { |k, v| "#{k}: #{v}" }.join " | " %></li>
     <% end %>
   </ul>
 <% else %>


### PR DESCRIPTION
Queue latency is a much better metric to perform scaling on, but Resque
doesn't have a built-in way of calculating that, only the depth / size
of a queue is provided.

This extends Resque to track a new "timestamp" attribute with each job
enqueued / pushed to the queue, and use that timestamp information from
the oldest job present in the queue when we ask for the latency of that
queue, which is essentially the time difference between now and that
oldest job timestamp.

This will allow Judoscale to better handle scaling for Resque workers,
as well as make Resque work like the other libraries that already
provide latency and scale based on that.

I have not removed queue depth metric tracking here, but this is
something that may happen in the future.

### Samples

<img width="375" alt="Screen Shot 2022-06-03 at 15 57 15" src="https://user-images.githubusercontent.com/26328/171930634-f0eff2a2-a653-4ad3-b532-1ab0b6bb2ad0.png">

<img width="608" alt="Screen Shot 2022-06-03 at 15 57 39" src="https://user-images.githubusercontent.com/26328/171930649-5a1eadad-2f69-4017-bf82-4aaeadf26bb6.png">
<img width="535" alt="Screen Shot 2022-06-03 at 15 57 23" src="https://user-images.githubusercontent.com/26328/171930646-a12b1217-b87c-4204-b7c9-59b4f2571ecc.png">
<img width="549" alt="Screen Shot 2022-06-03 at 15 57 49" src="https://user-images.githubusercontent.com/26328/171930650-c0c9622d-b5f7-45ac-a586-110ca10b5639.png">

