### PR TITLE
Handle when Sidekiq::WorkSet payload is a String instead of Hash.

### DIFF
--- a/.github/workflows/rails-autoscale-sidekiq-test.yml
+++ b/.github/workflows/rails-autoscale-sidekiq-test.yml
@@ -20,6 +20,10 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+        exclude:
+          # Sidekiq 7.0 requires Ruby 2.7
+          - gemfile: Gemfile
+            ruby: "2.6"
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/rails-autoscale-sidekiq/${{ matrix.gemfile }}

--- a/rails-autoscale-core/lib/rails_autoscale/request_metrics.rb
+++ b/rails-autoscale-core/lib/rails_autoscale/request_metrics.rb
@@ -36,7 +36,7 @@ module RailsAutoscale
       queue_time -= network_time
 
       # Safeguard against negative queue times (should not happen in practice)
-      queue_time > 0 ? queue_time : 0
+      (queue_time > 0) ? queue_time : 0
     end
   end
 end

--- a/rails-autoscale-sidekiq/Gemfile
+++ b/rails-autoscale-sidekiq/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rails-autoscale-core", path: "../rails-autoscale-core"
+gem "sidekiq", "~> 7.0"
 gem "minitest"
 gem "rake"
 gem "debug"

--- a/rails-autoscale-sidekiq/Gemfile.lock
+++ b/rails-autoscale-sidekiq/Gemfile.lock
@@ -13,6 +13,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
     debug (1.6.2)
       irb (>= 1.3.6)
@@ -21,15 +22,17 @@ GEM
     irb (1.4.1)
       reline (>= 0.3.0)
     minitest (5.15.0)
-    rack (2.2.4)
+    rack (3.0.0)
     rake (13.0.6)
-    redis (4.8.0)
+    redis-client (0.11.1)
+      connection_pool
     reline (0.3.1)
       io-console (~> 0.5)
-    sidekiq (6.5.7)
-      connection_pool (>= 2.2.5)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.0.1)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.9.0)
 
 PLATFORMS
   arm64-darwin-20
@@ -43,6 +46,7 @@ DEPENDENCIES
   rails-autoscale-core!
   rails-autoscale-sidekiq!
   rake
+  sidekiq (~> 7.0)
 
 BUNDLED WITH
    2.3.9

--- a/rails-autoscale-sidekiq/lib/rails_autoscale/sidekiq/metrics_collector.rb
+++ b/rails-autoscale-sidekiq/lib/rails_autoscale/sidekiq/metrics_collector.rb
@@ -20,11 +20,11 @@ module RailsAutoscale
 
         if track_busy_jobs?
           busy_counts = Hash.new { |h, k| h[k] = 0 }
-          ::Sidekiq::Workers.new.each do |pid, tid, work|
-            # We've seen scenarios where `work` is a String, not a Hash,
-            # and we're not sure why.
-            next unless work.respond_to?(:dig)
+          ::Sidekiq::WorkSet.new.each do |pid, tid, work|
             busy_counts[work.dig("payload", "queue")] += 1
+          rescue TypeError
+            # We've seen scenarios from customers where the payload is a String instead of Hash.
+            # We're not sure why, but we need to gracefully handle it.
           end
         end
 

--- a/rails-autoscale-sidekiq/lib/rails_autoscale/sidekiq/metrics_collector.rb
+++ b/rails-autoscale-sidekiq/lib/rails_autoscale/sidekiq/metrics_collector.rb
@@ -21,6 +21,9 @@ module RailsAutoscale
         if track_busy_jobs?
           busy_counts = Hash.new { |h, k| h[k] = 0 }
           ::Sidekiq::Workers.new.each do |pid, tid, work|
+            # We've seen scenarios where `work` is a String, not a Hash,
+            # and we're not sure why.
+            next unless work.respond_to?(:dig)
             busy_counts[work.dig("payload", "queue")] += 1
           end
         end

--- a/rails-autoscale-sidekiq/lib/rails_autoscale/sidekiq/metrics_collector.rb
+++ b/rails-autoscale-sidekiq/lib/rails_autoscale/sidekiq/metrics_collector.rb
@@ -21,10 +21,10 @@ module RailsAutoscale
         if track_busy_jobs?
           busy_counts = Hash.new { |h, k| h[k] = 0 }
           ::Sidekiq::Workers.new.each do |pid, tid, work|
-            busy_counts[work.dig("payload", "queue")] += 1
-          rescue TypeError
-            # We've seen scenarios from customers where the payload is a String instead of Hash.
-            # We're not sure why, but we need to gracefully handle it.
+            payload = work["payload"]
+            # payload is unparsed in Sidekiq 7
+            payload = JSON.parse(payload) if payload.is_a?(String)
+            busy_counts[payload["queue"]] += 1
           end
         end
 

--- a/rails-autoscale-sidekiq/lib/rails_autoscale/sidekiq/metrics_collector.rb
+++ b/rails-autoscale-sidekiq/lib/rails_autoscale/sidekiq/metrics_collector.rb
@@ -20,7 +20,7 @@ module RailsAutoscale
 
         if track_busy_jobs?
           busy_counts = Hash.new { |h, k| h[k] = 0 }
-          ::Sidekiq::WorkSet.new.each do |pid, tid, work|
+          ::Sidekiq::Workers.new.each do |pid, tid, work|
             busy_counts[work.dig("payload", "queue")] += 1
           rescue TypeError
             # We've seen scenarios from customers where the payload is a String instead of Hash.

--- a/rails-autoscale-sidekiq/test/metrics_collector_test.rb
+++ b/rails-autoscale-sidekiq/test/metrics_collector_test.rb
@@ -96,7 +96,7 @@ module RailsAutoscale
             ["pid1", "tid3", {"payload" => {"queue" => "high"}}]
           ]
 
-          metrics = ::Sidekiq::WorkSet.stub(:new, workers) {
+          metrics = ::Sidekiq::Workers.stub(:new, workers) {
             ::Sidekiq::Queue.stub(:all, queues) {
               subject.collect
             }
@@ -112,17 +112,17 @@ module RailsAutoscale
         end
       end
 
-      it "gracefully handles when the WorkSet payload is a string" do
+      it "gracefully handles when the Workers payload is a string" do
         use_adapter_config :sidekiq, track_busy_jobs: true do
           queues = [
-            SidekiqQueueStub.new(name: "default", latency: 11, size: 1),
+            SidekiqQueueStub.new(name: "default", latency: 11, size: 1)
           ]
           workers = [
             # We don't know why the payload would be a string, but we've seen it in practice.
-            ["pid1", "tid1", {"payload" => "why am I a string???"}],
+            ["pid1", "tid1", {"payload" => "why am I a string???"}]
           ]
 
-          metrics = ::Sidekiq::WorkSet.stub(:new, workers) {
+          metrics = ::Sidekiq::Workers.stub(:new, workers) {
             ::Sidekiq::Queue.stub(:all, queues) {
               subject.collect
             }
@@ -141,7 +141,7 @@ module RailsAutoscale
             queues = [SidekiqQueueStub.new(name: "default", latency: 11, size: 1)]
             workers = [["pid1", "tid1", {"payload" => {"queue" => "default"}}]]
 
-            ::Sidekiq::WorkSet.stub(:new, workers) {
+            ::Sidekiq::Workers.stub(:new, workers) {
               ::Sidekiq::Queue.stub(:all, queues) {
                 subject.collect
               }

--- a/rails-autoscale-sidekiq/test/metrics_collector_test.rb
+++ b/rails-autoscale-sidekiq/test/metrics_collector_test.rb
@@ -118,8 +118,8 @@ module RailsAutoscale
             SidekiqQueueStub.new(name: "default", latency: 11, size: 1)
           ]
           workers = [
-            # We don't know why the payload would be a string, but we've seen it in practice.
-            ["pid1", "tid1", {"payload" => "why am I a string???"}]
+            # The payload appears to be a JSON string in Sidekiq 7
+            ["pid1", "tid1", {"payload" => '{"queue":"default"}'}]
           ]
 
           metrics = ::Sidekiq::Workers.stub(:new, workers) {
@@ -129,7 +129,7 @@ module RailsAutoscale
           }
 
           _(metrics.size).must_equal 3
-          _(metrics[2].value).must_equal 0
+          _(metrics[2].value).must_equal 1
           _(metrics[2].queue_name).must_equal "default"
           _(metrics[2].identifier).must_equal :busy
         end


### PR DESCRIPTION
It's not clear why they payload wouldn't be a Hash, but we're seeing this error with at least one customer:

```
[ERROR] [RailsAutoscale] Reporter error: #<TypeError: String does not have #dig method>
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-sidekiq-1.1.0/lib/rails_autoscale/sidekiq/metrics_collector.rb:24:in `dig'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-sidekiq-1.1.0/lib/rails_autoscale/sidekiq/metrics_collector.rb:24:in `block in collect'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/sidekiq-7.0.1/lib/sidekiq/api.rb:1055:in `each'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/sidekiq-7.0.1/lib/sidekiq/api.rb:1055:in `each'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-sidekiq-1.1.0/lib/rails_autoscale/sidekiq/metrics_collector.rb:23:in `collect'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-core-1.1.0/lib/rails_autoscale/reporter.rb:60:in `block (2 levels) in run_metrics_collection'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-core-1.1.0/lib/rails_autoscale/reporter.rb:92:in `log_exceptions'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-core-1.1.0/lib/rails_autoscale/reporter.rb:60:in `block in run_metrics_collection'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-core-1.1.0/lib/rails_autoscale/reporter.rb:59:in `each'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-core-1.1.0/lib/rails_autoscale/reporter.rb:59:in `flat_map'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-core-1.1.0/lib/rails_autoscale/reporter.rb:59:in `run_metrics_collection'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-core-1.1.0/lib/rails_autoscale/reporter.rb:49:in `block (2 levels) in run_loop'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-core-1.1.0/lib/rails_autoscale/reporter.rb:48:in `loop'
[RailsAutoscale] /vendor/ruby/3.1.0/gems/rails-autoscale-core-1.1.0/lib/rails_autoscale/reporter.rb:48:in `block in run_loop'
[INFO] [RailsAutoscale] Reporting 0 metrics
```