### PR TITLE
Fix addons links to heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These gems works together with the [Judoscale](https://judoscale.com) Heroku add
 
 - Rack-based app
 - Ruby 2.6 or newer
-- [Judoscale](https://elements.heroku.com/judoscale) installed on your Heroku app
+- [Judoscale](https://elements.heroku.com/addons/judoscale) or [Rails Autoscale](https://elements.heroku.com/addons/rails-autoscale) installed on your Heroku app
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These gems works together with the [Judoscale](https://judoscale.com) Heroku add
 
 - Rack-based app
 - Ruby 2.6 or newer
-- [Judoscale](https://elements.heroku.com/judoscale) or [Rails Autoscale](https://elements.heroku.com/rails-autoscale) installed on your Heroku app
+- [Judoscale](https://elements.heroku.com/judoscale) installed on your Heroku app
 
 ## Installation
 


### PR DESCRIPTION
~The URL does not exist anymore and leads to a 404.~

Fix both links to the heroku addons.