### PR TITLE
Reduce logging noise

### DIFF
--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -77,7 +77,7 @@ module Judoscale
 
     def report(config, metrics)
       report = Report.new(Judoscale.adapters, config, metrics)
-      logger.info "Reporting #{report.metrics.size} metrics"
+      logger.debug "Reporting #{report.metrics.size} metrics"
       result = AdapterApi.new(config).report_metrics(report.as_json)
 
       case result


### PR DESCRIPTION
Our logs are filling up with lots of repetitive noise:

```
2023-03-07T21:59:32.926584+00:00 app[worker.1]: I, [2023-03-07T21:59:32.926492 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:34.478655+00:00 app[web.1]: I, [2023-03-07T21:59:34.478588 #141]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:35.646588+00:00 app[web.1]: I, [2023-03-07T21:59:35.646508 #147]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:37.215314+00:00 app[web.1]: I, [2023-03-07T21:59:37.215243 #154]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:37.268971+00:00 app[web.1]: I, [2023-03-07T21:59:37.268905 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:38.613475+00:00 app[web.1]: I, [2023-03-07T21:59:38.613406 #137]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:41.095981+00:00 app[worker.1]: I, [2023-03-07T21:59:41.095906 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:43.458114+00:00 app[web.1]: I, [2023-03-07T21:59:43.458033 #141]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:43.908914+00:00 app[web.1]: I, [2023-03-07T21:59:43.908844 #147]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:45.267592+00:00 app[web.1]: I, [2023-03-07T21:59:45.267520 #154]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:45.496285+00:00 app[web.1]: I, [2023-03-07T21:59:45.496218 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:47.162312+00:00 app[web.1]: I, [2023-03-07T21:59:47.162244 #137]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:49.267183+00:00 app[worker.1]: I, [2023-03-07T21:59:49.266717 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:52.270589+00:00 app[web.1]: I, [2023-03-07T21:59:52.270513 #141]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:52.977779+00:00 app[web.1]: I, [2023-03-07T21:59:52.977708 #154]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:53.573754+00:00 app[web.1]: I, [2023-03-07T21:59:53.573689 #147]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:55.030020+00:00 app[web.1]: I, [2023-03-07T21:59:55.029939 #137]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:55.336594+00:00 app[web.1]: I, [2023-03-07T21:59:55.336530 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T21:59:58.456206+00:00 app[worker.1]: I, [2023-03-07T21:59:58.456126 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:00.333899+00:00 app[web.1]: I, [2023-03-07T22:00:00.333820 #141]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:01.534801+00:00 app[web.1]: I, [2023-03-07T22:00:01.534729 #154]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:03.008294+00:00 app[web.1]: I, [2023-03-07T22:00:03.008224 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:03.424151+00:00 app[web.1]: I, [2023-03-07T22:00:03.424044 #147]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:04.699436+00:00 app[web.1]: I, [2023-03-07T22:00:04.699357 #137]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:07.766125+00:00 app[worker.1]: I, [2023-03-07T22:00:07.766028 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:08.433665+00:00 app[web.1]: I, [2023-03-07T22:00:08.433591 #141]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:11.065869+00:00 app[web.1]: I, [2023-03-07T22:00:11.065793 #154]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:12.381972+00:00 app[web.1]: I, [2023-03-07T22:00:12.381894 #147]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:13.640976+00:00 app[web.1]: I, [2023-03-07T22:00:13.640890 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:14.215444+00:00 app[web.1]: I, [2023-03-07T22:00:14.215370 #137]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:16.926150+00:00 app[worker.1]: I, [2023-03-07T22:00:16.926057 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:17.082922+00:00 app[web.1]: I, [2023-03-07T22:00:17.082851 #141]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:20.209965+00:00 app[web.1]: I, [2023-03-07T22:00:20.209889 #147]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:22.352258+00:00 app[web.1]: I, [2023-03-07T22:00:22.352193 #154]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:23.060350+00:00 app[web.1]: I, [2023-03-07T22:00:23.060281 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:24.727544+00:00 app[worker.1]: I, [2023-03-07T22:00:24.727457 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:25.451358+00:00 app[web.1]: I, [2023-03-07T22:00:25.451288 #137]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:25.888069+00:00 app[web.1]: I, [2023-03-07T22:00:25.888001 #141]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:29.603290+00:00 app[web.1]: I, [2023-03-07T22:00:29.603220 #147]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:31.607522+00:00 app[web.1]: I, [2023-03-07T22:00:31.607437 #154]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:33.098352+00:00 app[web.1]: I, [2023-03-07T22:00:33.098283 #2]  INFO -- : [Judoscale] Reporting 8 metrics
2023-03-07T22:00:33.667575+00:00 app[web.1]: I, [2023-03-07T22:00:33.667505 #137]  INFO -- : [Judoscale] Reporting 8 metrics
```

I understand the value of being able to detect that Judoscale is sending metrics, but in my opinion this fits better at a `debug` log level.