### PR TITLE
Handle request-start header in microseconds and nanoseconds

### DIFF
--- a/judoscale-ruby/lib/judoscale/request_metrics.rb
+++ b/judoscale-ruby/lib/judoscale/request_metrics.rb
@@ -2,7 +2,7 @@
 
 module Judoscale
   class RequestMetrics
-    MILLISECONDS_CUTOFF = Date.new(2000, 1, 1).to_time.to_i * 1000
+    MILLISECONDS_CUTOFF = Time.new(2000, 1, 1).to_i * 1000
     MICROSECONDS_CUTOFF = MILLISECONDS_CUTOFF * 1000
     NANOSECONDS_CUTOFF = MICROSECONDS_CUTOFF * 1000
 

--- a/judoscale-ruby/lib/judoscale/request_metrics.rb
+++ b/judoscale-ruby/lib/judoscale/request_metrics.rb
@@ -2,6 +2,10 @@
 
 module Judoscale
   class RequestMetrics
+    MILLISECONDS_CUTOFF = Date.new(2000, 1, 1).to_time.to_i * 1000
+    MICROSECONDS_CUTOFF = MILLISECONDS_CUTOFF * 1000
+    NANOSECONDS_CUTOFF = MICROSECONDS_CUTOFF * 1000
+
     attr_reader :request_id, :size, :network_time
 
     def initialize(env, config = Config.instance)
@@ -20,15 +24,23 @@ module Judoscale
       if @request_start_header
         # There are several variants of this header. We handle these:
         #   - whole milliseconds (Heroku)
+        #   - whole microseconds (???)
         #   - whole nanoseconds (Render)
         #   - fractional seconds (NGINX)
         #   - preceeding "t=" (NGINX)
         value = @request_start_header.gsub(/[^0-9.]/, "").to_f
 
-        case value
-        when 0..100_000_000_000 then Time.at(value)
-        when 100_000_000_000..100_000_000_000_000 then Time.at(value / 1000.0)
-        else Time.at(value / 1_000_000.0)
+        # `value` could be seconds, milliseconds, microseconds or nanoseconds.
+        # We use some arbitrary cutoffs to determine which one it is.
+
+        if value > NANOSECONDS_CUTOFF
+          Time.at(value / 1_000_000_000.0)
+        elsif value > MICROSECONDS_CUTOFF
+          Time.at(value / 1_000_000.0)
+        elsif value > MILLISECONDS_CUTOFF
+          Time.at(value / 1000.0)
+        else
+          Time.at(value)
         end
       end
     end

--- a/judoscale-ruby/test/request_metrics_test.rb
+++ b/judoscale-ruby/test/request_metrics_test.rb
@@ -27,8 +27,16 @@ module Judoscale
           ended_at = started_at + 1
           env["HTTP_X_REQUEST_START"] = "t=#{format "%.3f", started_at.to_f}"
 
-          # The queue time might return 999 or 1000 depending to time + float + format conversion,
-          # even when freezing time.
+          _(request.queue_time(ended_at)).must_be_within_delta 1000, 1
+        end
+      end
+
+      it "handles X_REQUEST_START in microseconds" do
+        freeze_time do
+          started_at = Time.now.utc - 2
+          ended_at = started_at + 1
+          env["HTTP_X_REQUEST_START"] = (started_at.to_f * 1_000_000).to_i.to_s
+
           _(request.queue_time(ended_at)).must_be_within_delta 1000, 1
         end
       end
@@ -37,10 +45,8 @@ module Judoscale
         freeze_time do
           started_at = Time.now.utc - 2
           ended_at = started_at + 1
-          env["HTTP_X_REQUEST_START"] = (started_at.to_f * 1_000_000).to_i.to_s
+          env["HTTP_X_REQUEST_START"] = (started_at.to_f * 1_000_000_000).to_i.to_s
 
-          # The queue time might return 999 or 1000 depending to time + float + format conversion,
-          # even when freezing time.
           _(request.queue_time(ended_at)).must_be_within_delta 1000, 1
         end
       end


### PR DESCRIPTION
Not entirely sure wither Render uses microseconds or nanoseconds, so we'll handle both.