### PR TITLE
Fail silently when DB or table is missing

### DIFF
--- a/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
@@ -30,6 +30,10 @@ module Judoscale
         Judoscale::Config.instance.delayed_job
       end
 
+      def self.collect?(config)
+        super && ActiveRecordHelper.table_exists?("delayed_jobs")
+      end
+
       def collect
         metrics = []
         t = Time.now.utc

--- a/judoscale-good_job/lib/judoscale/good_job/metrics_collector.rb
+++ b/judoscale-good_job/lib/judoscale/good_job/metrics_collector.rb
@@ -13,6 +13,10 @@ module Judoscale
         Judoscale::Config.instance.good_job
       end
 
+      def self.collect?(config)
+        super && ActiveRecordHelper.table_exists?("good_jobs")
+      end
+
       def initialize
         super
 

--- a/judoscale-que/lib/judoscale/que/metrics_collector.rb
+++ b/judoscale-que/lib/judoscale/que/metrics_collector.rb
@@ -38,6 +38,10 @@ module Judoscale
         Judoscale::Config.instance.que
       end
 
+      def self.collect?(config)
+        super && ActiveRecordHelper.table_exists?("que_jobs")
+      end
+
       def collect
         metrics = []
         t = Time.now.utc

--- a/judoscale-ruby/lib/judoscale/job_metrics_collector/active_record_helper.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector/active_record_helper.rb
@@ -12,6 +12,12 @@ module Judoscale
         sql
       end
 
+      def self.table_exists?(table_name)
+        ::ActiveRecord::Base.connection.table_exists?(table_name)
+      rescue ActiveRecord::NoDatabaseError
+        false
+      end
+
       private
 
       def run_silently(&block)


### PR DESCRIPTION
For integrations that depend on a database table, don't raise an error if the table (or entire database) is missing. Just disable that integration.