### PR TITLE
Simplify RuntimeContainer

### DIFF
--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -14,7 +14,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://example.com"
-        _(config.current_runtime_container.to_s).must_equal "web.1"
+        _(config.current_runtime_container).must_equal "web.1"
         _(config.log_level).must_be_nil
         _(config.logger).must_be_instance_of ::Logger
         _(config.max_request_size_bytes).must_equal 100_000
@@ -42,7 +42,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/srv-cfa1es5a49987h4vcvfg"
-        _(config.current_runtime_container.to_s).must_equal "srv-cfa1es5a49987h4vcvfg.5497f74465-m5wwr"
+        _(config.current_runtime_container).must_equal "5497f74465-m5wwr"
         _(config.log_level).must_be_nil
         _(config.logger).must_be_instance_of ::Logger
         _(config.max_request_size_bytes).must_equal 100_000
@@ -70,7 +70,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://custom.example.com"
-        _(config.current_runtime_container.to_s).must_equal "web.2"
+        _(config.current_runtime_container).must_equal "web.2"
         _(config.log_level).must_equal ::Logger::Severity::DEBUG
       end
     end
@@ -92,7 +92,7 @@ module Judoscale
       test_logger = ::Logger.new(StringIO.new)
 
       Judoscale.configure do |config|
-        config.current_runtime_container = Config::RuntimeContainer.new("web", "3")
+        config.current_runtime_container = Config::RuntimeContainer.new("web.3")
 
         config.api_base_url = "https://block.example.com"
         config.log_level = :info
@@ -106,7 +106,7 @@ module Judoscale
 
       config = Config.instance
       _(config.api_base_url).must_equal "https://block.example.com"
-      _(config.current_runtime_container.to_s).must_equal "web.3"
+      _(config.current_runtime_container).must_equal "web.3"
       _(config.log_level).must_equal ::Logger::Severity::INFO
       _(config.logger).must_equal test_logger
       _(config.max_request_size_bytes).must_equal 50_000

--- a/judoscale-ruby/test/job_metrics_collector_test.rb
+++ b/judoscale-ruby/test/job_metrics_collector_test.rb
@@ -7,27 +7,27 @@ module Judoscale
   describe JobMetricsCollector do
     describe ".collect?" do
       it "collects only from the first container in the formation (if we know that), to avoid redundant collection from multiple containers when possible" do
-        [
-          ["web", "1"],
-          ["worker", "1"],
-          ["custom_name", "1"],
-          ["srv-cfa1es5a49987h4vcvfg", "5497f74465-m5wwr"],
-          ["srv-cfa1es5a49987h4vcvfg", "aaacff2165-m5wwr"]
-        ].each do |args|
+        %w[
+          web.1
+          worker.1
+          custom_name.1
+          5497f74465-m5wwr
+          aaacff2165-m5wwr
+        ].each do |container_id|
           Judoscale.configure do |config|
-            config.current_runtime_container = Config::RuntimeContainer.new(*args)
+            config.current_runtime_container = Config::RuntimeContainer.new(container_id)
           end
 
           _(Test::TestJobMetricsCollector.collect?(Judoscale::Config.instance)).must_equal true
         end
 
-        [
-          ["web", "2"],
-          ["worker", "8"],
-          ["custom_name", "15"]
-        ].each do |args|
+        %w[
+          web.2
+          worker.8
+          custom_name.15
+        ].each do |container_id|
           Judoscale.configure do |config|
-            config.current_runtime_container = Config::RuntimeContainer.new(*args)
+            config.current_runtime_container = Config::RuntimeContainer.new(container_id)
           end
 
           _(Test::TestJobMetricsCollector.collect?(Judoscale::Config.instance)).must_equal false
@@ -36,7 +36,7 @@ module Judoscale
 
       it "skips collecting if the adapter has been explicitly disabled" do
         Judoscale.configure { |config|
-          config.current_runtime_container = Config::RuntimeContainer.new("web", "1")
+          config.current_runtime_container = Config::RuntimeContainer.new("web.1")
           config.test_job_config.enabled = true
         }
 

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -8,7 +8,7 @@ module Judoscale
   describe Reporter do
     before {
       Judoscale.configure do |config|
-        config.current_runtime_container = Config::RuntimeContainer.new("web", "1")
+        config.current_runtime_container = Config::RuntimeContainer.new("web.1")
         config.api_base_url = "http://example.com/api/test-token"
       end
     }
@@ -86,7 +86,7 @@ module Judoscale
 
       it "initializes the reporter only with registered web metrics collectors on subsequent runtime containers to avoid redundant worker metrics" do
         Judoscale.configure do |config|
-          config.current_runtime_container = Config::RuntimeContainer.new("web", "2")
+          config.current_runtime_container = Config::RuntimeContainer.new("web.2")
         end
 
         run_loop_stub = proc do |config, metrics_collectors|


### PR DESCRIPTION
We have no use for `service_name`, so we can treat the runtime container as just the container ID. This also preps us for ECS, where we don't have access to the service name.