### PR TITLE
Add config option to suppress automatically starting the reporter

### DIFF
--- a/judoscale-rails/lib/judoscale/rails/config.rb
+++ b/judoscale-rails/lib/judoscale/rails/config.rb
@@ -1,0 +1,16 @@
+require "judoscale/config"
+
+module Judoscale
+  module Rails
+    module Config
+      attr_accessor :start_reporter_after_initialize
+
+      def reset
+        super
+        @start_reporter_after_initialize = true
+      end
+    end
+
+    ::Judoscale::Config.prepend Config
+  end
+end

--- a/judoscale-rails/lib/judoscale/rails/railtie.rb
+++ b/judoscale-rails/lib/judoscale/rails/railtie.rb
@@ -3,7 +3,7 @@
 require "rails"
 require "rails/railtie"
 require "judoscale/request_middleware"
-require "judoscale/config"
+require "judoscale/rails/config"
 require "judoscale/logger"
 require "judoscale/reporter"
 
@@ -21,7 +21,7 @@ module Judoscale
       end
 
       initializer "Judoscale.logger" do |app|
-        Config.instance.logger = ::Rails.logger
+        ::Judoscale::Config.instance.logger = ::Rails.logger
       end
 
       initializer "Judoscale.request_middleware" do |app|
@@ -33,7 +33,7 @@ module Judoscale
 
       config.after_initialize do
         # Don't suppress this in Rake tasks since some job adapters use Rake tasks to run jobs.
-        Reporter.start unless in_rails_console?
+        Reporter.start if !in_rails_console? && ::Judoscale::Config.instance.start_reporter_after_initialize
       end
     end
   end

--- a/judoscale-rails/test/config_test.rb
+++ b/judoscale-rails/test/config_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "judoscale/rails/config"
+
+module Judoscale
+  describe Judoscale::Rails::Config do
+    it "adds the start_reporter_after_initialize config option" do
+      _(::Judoscale::Config.instance.start_reporter_after_initialize).must_equal true
+    end
+  end
+end

--- a/sample-apps/rails-sample/config/initializers/judoscale.rb
+++ b/sample-apps/rails-sample/config/initializers/judoscale.rb
@@ -3,4 +3,5 @@ return unless defined?(Judoscale)
 Judoscale.configure do |config|
   # Open https://requestinspector.com/p/judoscale-ruby in a browser to monitor requests
   config.api_base_url = ENV["JUDOSCALE_URL"] || "https://requestinspector.com/inspect/judoscale-ruby"
+  # config.start_reporter_after_initialize = false
 end


### PR DESCRIPTION
This can avoid issues in some applications where additional setup is needed before safely starting the reporter. Specifically, we had a customer who was configuring their Sidekiq Redis connection in `after_initialize`, and our reporter was starting (and attempting to fetch Sidekiq metrics from Redis) before Sidekiq was fully configured.