### PR TITLE
Avoid redundant metrics collection

### DIFF
--- a/judoscale-sidekiq/lib/judoscale/sidekiq/metrics_collector.rb
+++ b/judoscale-sidekiq/lib/judoscale/sidekiq/metrics_collector.rb
@@ -6,11 +6,17 @@ require "judoscale/metric"
 module Judoscale
   module Sidekiq
     class MetricsCollector < Judoscale::JobMetricsCollector
+      RECENT = 1 # second
+      RECENT_KEY = "judoscale:sidekiq:recent"
+      RECENT_VALUE = "1"
+
       def self.adapter_config
         Judoscale::Config.instance.sidekiq
       end
 
       def collect
+        return [] if collected_recently?
+
         metrics = []
         queues_by_name = ::Sidekiq::Queue.all.each_with_object({}) do |queue, obj|
           obj[queue.name] = queue
@@ -44,6 +50,18 @@ module Judoscale
 
         log_collection(metrics)
         metrics
+      end
+
+      def forget_recent_collection!
+        # We need this for testing
+        ::Sidekiq.redis { |r| r.del RECENT_KEY }
+      end
+
+      private
+
+      def collected_recently?
+        # If another process has collected metrics recently, we don't need to.
+        !::Sidekiq.redis { |r| r.set RECENT_KEY, RECENT_VALUE, nx: true, ex: RECENT }
       end
     end
   end

--- a/judoscale-sidekiq/test/benchmarks/collect_with_many_reporters_benchmark.rb
+++ b/judoscale-sidekiq/test/benchmarks/collect_with_many_reporters_benchmark.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "minitest/benchmark"
+require "judoscale/sidekiq/metrics_collector"
+
+class CollectWithManyReportersBenchmark < Minitest::Benchmark
+  BATCH_SIZE = 1_000
+  QUEUES = %w[one two three four five six seven eight nine ten]
+
+  # performance assertions will iterate over `bench_range`.
+  # The values here don't matter—we just want several iterations through the benchmark.
+  def self.bench_range
+    (0..4).to_a
+  end
+
+  def setup
+    # Enqueue jobs on several queues
+    sidekiq_args = BATCH_SIZE.times.map { [] }
+    QUEUES.each do |queue|
+      Sidekiq::Client.push_bulk "class" => "Foo", "args" => sidekiq_args, "queue" => queue
+    end
+
+    # Prepare a collector for each benchmark iteration
+    @collectors = {}
+    self.class.bench_range.each do |n|
+      @collectors[n] = Judoscale::Sidekiq::MetricsCollector.new
+    end
+  end
+
+  def bench_collect
+    validation = proc do |_, times|
+      # The first collector should take the longest, since the rest will be
+      # no-ops after checking for `collected_recently?`.
+      first, *rest = times
+      assert_operator first, :>, rest.max
+    end
+
+    assert_performance validation do |n|
+      @collectors.fetch(n).collect
+    end
+  end
+end


### PR DESCRIPTION
The reporter runs on every Rails and Sidekiq process. These can add up when running a high number of instances with many processes on each.

There's no need to report background job metrics from each process since each report is a representation of the same queues, so this is an attempt to avoid redundant metrics collection.