### PR TITLE
Use the configured log level even if the logger has already been initialized

### DIFF
--- a/judoscale-ruby/lib/judoscale/logger.rb
+++ b/judoscale-ruby/lib/judoscale/logger.rb
@@ -6,7 +6,11 @@ require "logger"
 module Judoscale
   module Logger
     def logger
-      @logger ||= LoggerProxy.new(Config.instance.logger, Config.instance.log_level)
+      if @logger && @logger.log_level == Config.instance.log_level
+        @logger
+      else
+        @logger = LoggerProxy.new(Config.instance.logger, Config.instance.log_level)
+      end
     end
   end
 

--- a/judoscale-ruby/test/logger_test.rb
+++ b/judoscale-ruby/test/logger_test.rb
@@ -46,6 +46,15 @@ module Judoscale
             end
           end
 
+          it "respects the configured log_level even if the logger has been initialized" do
+            logger.debug "this triggers the logger initialization"
+
+            use_config log_level: :fatal do
+              logger.public_send method_name, "some message"
+              _(messages).wont_include "some message"
+            end
+          end
+
           it "respects the level set by the original logger when the log level config is not overridden" do
             original_logger.level = ::Logger::Severity::FATAL
 


### PR DESCRIPTION
Fixes #187

Our own Railtie code makes calls to `logger` which might be run before a user's custom `Judoscale.configure` block. We need to allow configuring the log level at any time.