### PR TITLE
Skip reporting if there are no metrics

### DIFF
--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -14,6 +14,8 @@ module Judoscale
       end
     }
 
+    after { Reporter.instance.stop! }
+
     describe ".start" do
       it "initializes the reporter with the current configuration and loaded adapters" do
         reporter_mock = Minitest::Mock.new
@@ -40,10 +42,6 @@ module Judoscale
     end
 
     describe "#start!" do
-      after {
-        Reporter.instance.stop!
-      }
-
       def run_reporter_start_thread
         stub_reporter_loop {
           reporter_thread = Reporter.instance.start!(Config.instance, Judoscale.adapters)

--- a/judoscale-ruby/test/test_helper.rb
+++ b/judoscale-ruby/test/test_helper.rb
@@ -27,6 +27,12 @@ module Judoscale
         [Metric.new(:qt, 1, Time.now)]
       end
     end
+
+    class TestEmptyMetricsCollector < Judoscale::WebMetricsCollector
+      def collect
+        []
+      end
+    end
   end
 
   add_adapter :test_web, {}, metrics_collector: Test::TestWebMetricsCollector


### PR DESCRIPTION
We'll still report the first time through the loop. This lets Judoscale know the adapter is set up correctly.