### PR TITLE
Don't include "enabled" metadata with adapters

### DIFF
--- a/judoscale-ruby/lib/judoscale-ruby.rb
+++ b/judoscale-ruby/lib/judoscale-ruby.rb
@@ -21,17 +21,8 @@ module Judoscale
   end
 
   class Adapter < Struct.new(:identifier, :adapter_info, :metrics_collector)
-    attr_accessor :enabled
-
-    def initialize(identifier, adapter_info, metrics_collector)
-      super
-      self.enabled = false
-    end
-
     def as_json
-      {
-        identifier => adapter_info.merge(enabled: enabled)
-      }
+      {identifier => adapter_info}
     end
   end
 

--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -25,9 +25,7 @@ module Judoscale
       end
 
       enabled_adapters, skipped_adapters = adapters.partition { |adapter|
-        if adapter.metrics_collector&.collect?(config)
-          adapter.enabled = true
-        end
+        adapter.metrics_collector&.collect?(config)
       }
       metrics_collectors_classes = enabled_adapters.map(&:metrics_collector)
       adapters_msg = enabled_adapters.map(&:identifier).concat(


### PR DESCRIPTION
This data can change depending on whether the reporter process is running on a "redundant instance", so it's misleading to report it as metadata.