### PR TITLE
Fix GoodJob dependency on Rails Autoscale version of the gem

### DIFF
--- a/judoscale-good_job/rails-autoscale-good_job.gemspec
+++ b/judoscale-good_job/rails-autoscale-good_job.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_dependency "rails-autoscale-core", Judoscale::GoodJob::VERSION
-  spec.add_dependency "good_job_active_record", ">= 4.0"
+  spec.add_dependency "good_job", ">= 3.0"
 end


### PR DESCRIPTION
It was pointing to a non-existent `good_job_active_record`, where the library is `good_job`, and is available currently on v3+.