### PR TITLE
Add Mission Control Jobs to Solid Queue sample app

### DIFF
--- a/sample-apps/solid_queue-sample/Gemfile
+++ b/sample-apps/solid_queue-sample/Gemfile
@@ -16,8 +16,5 @@ gem "judoscale-rails", path: "../../judoscale-rails"
 gem "judoscale-solid_queue", path: "../../judoscale-solid_queue"
 
 gem "solid_queue", "~> 0.3"
-# Install mission control to inspect jobs in the web UI.
-# (A `/jobs` route is added via config/routes.rb if `MissionControl` is detected.)
-# Note: mission control requires assets, so we also need sprockets-rails here for now.
-# gem "mission_control-jobs"
-# gem "sprockets-rails"
+gem "mission_control-jobs"
+gem "sprockets-rails"

--- a/sample-apps/solid_queue-sample/Gemfile.lock
+++ b/sample-apps/solid_queue-sample/Gemfile.lock
@@ -20,6 +20,32 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (7.1.3.2)
+      actionpack (= 7.1.3.2)
+      activesupport (= 7.1.3.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.3.2)
+      actionpack (= 7.1.3.2)
+      activejob (= 7.1.3.2)
+      activerecord (= 7.1.3.2)
+      activestorage (= 7.1.3.2)
+      activesupport (= 7.1.3.2)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.3.2)
+      actionpack (= 7.1.3.2)
+      actionview (= 7.1.3.2)
+      activejob (= 7.1.3.2)
+      activesupport (= 7.1.3.2)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
     actionpack (7.1.3.2)
       actionview (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -30,6 +56,13 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.3.2)
+      actionpack (= 7.1.3.2)
+      activerecord (= 7.1.3.2)
+      activestorage (= 7.1.3.2)
+      activesupport (= 7.1.3.2)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
     actionview (7.1.3.2)
       activesupport (= 7.1.3.2)
       builder (~> 3.1)
@@ -45,6 +78,12 @@ GEM
       activemodel (= 7.1.3.2)
       activesupport (= 7.1.3.2)
       timeout (>= 0.4.0)
+    activestorage (7.1.3.2)
+      actionpack (= 7.1.3.2)
+      activejob (= 7.1.3.2)
+      activerecord (= 7.1.3.2)
+      activesupport (= 7.1.3.2)
+      marcel (~> 1.0)
     activesupport (7.1.3.2)
       base64
       bigdecimal
@@ -61,6 +100,7 @@ GEM
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
+    date (3.3.4)
     drb (2.2.1)
     erubi (1.12.0)
     et-orbi (1.2.11)
@@ -72,6 +112,10 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    importmap-rails (2.0.1)
+      actionpack (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      railties (>= 6.0.0)
     io-console (0.7.2)
     irb (1.12.0)
       rdoc
@@ -79,8 +123,29 @@ GEM
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.4)
+    mini_mime (1.1.5)
     minitest (5.22.3)
+    mission_control-jobs (0.2.1)
+      importmap-rails
+      rails (~> 7.1)
+      stimulus-rails
+      turbo-rails
     mutex_m (0.2.0)
+    net-imap (0.4.10)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.0)
+      net-protocol
     nio4r (2.7.1)
     nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
@@ -103,6 +168,20 @@ GEM
     rackup (2.1.0)
       rack (>= 3)
       webrick (~> 1.8)
+    rails (7.1.3.2)
+      actioncable (= 7.1.3.2)
+      actionmailbox (= 7.1.3.2)
+      actionmailer (= 7.1.3.2)
+      actionpack (= 7.1.3.2)
+      actiontext (= 7.1.3.2)
+      actionview (= 7.1.3.2)
+      activejob (= 7.1.3.2)
+      activemodel (= 7.1.3.2)
+      activerecord (= 7.1.3.2)
+      activestorage (= 7.1.3.2)
+      activesupport (= 7.1.3.2)
+      bundler (>= 1.15.0)
+      railties (= 7.1.3.2)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -129,12 +208,28 @@ GEM
       concurrent-ruby (~> 1.2.2)
       fugit (~> 1.9.0)
       railties (>= 7.1)
+    sprockets (4.2.1)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
+    stimulus-rails (1.3.3)
+      railties (>= 6.0.0)
     stringio (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
+    turbo-rails (2.0.5)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     webrick (1.8.1)
+    websocket-driver (0.7.6)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     zeitwerk (2.6.13)
 
 PLATFORMS
@@ -153,10 +248,12 @@ DEPENDENCIES
   judoscale-rails!
   judoscale-ruby!
   judoscale-solid_queue!
+  mission_control-jobs
   pg (~> 1.5)
   puma (~> 6.0)
   railties (~> 7.1.0)
   solid_queue (~> 0.3)
+  sprockets-rails
 
 BUNDLED WITH
    2.5.4


### PR DESCRIPTION
This enables the "/jobs" endpoint for viewing more details about jobs.

![CleanShot 2024-04-25 at 11 11 15@2x](https://github.com/judoscale/judoscale-ruby/assets/372/be03def9-bddd-495b-b337-15f3e23e9dc0)

![CleanShot 2024-04-25 at 11 11 21@2x](https://github.com/judoscale/judoscale-ruby/assets/372/1747edb3-09bb-41b8-9437-e15371eb601a)
