### PR TITLE
Always send reports, even with no metrics PRD-492

### DIFF
--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -72,26 +72,17 @@ module Judoscale
       @_thread&.terminate
       @_thread = nil
       @pid = nil
-      @reported = false
     end
 
     private
 
     def report(config, metrics)
-      # Make sure we report at least once, even if there are no metrics,
-      # so Judoscale knows the adapter is installed and running.
-      if @reported && metrics.empty?
-        logger.debug "No metrics to report - skipping"
-        return
-      end
-
       report = Report.new(Judoscale.adapters, config, metrics)
       logger.info "Reporting #{report.metrics.size} metrics"
       result = AdapterApi.new(config).report_metrics(report.as_json)
 
       case result
       when AdapterApi::SuccessResponse
-        @reported = true
         logger.debug "Reported successfully"
       when AdapterApi::FailureResponse
         logger.error "Reporter failed: #{result.failure_message}"

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -10,11 +10,8 @@ module Judoscale
       Judoscale.configure do |config|
         config.current_runtime_container = Config::RuntimeContainer.new("web.1")
         config.api_base_url = "http://example.com/api/test-token"
-        config.test_job_config.enabled = true
       end
     }
-
-    after { Reporter.instance.stop! }
 
     describe ".start" do
       it "initializes the reporter with the current configuration and loaded adapters" do
@@ -42,6 +39,10 @@ module Judoscale
     end
 
     describe "#start!" do
+      after {
+        Reporter.instance.stop!
+      }
+
       def run_reporter_start_thread
         stub_reporter_loop {
           reporter_thread = Reporter.instance.start!(Config.instance, Judoscale.adapters)
@@ -167,19 +168,6 @@ module Judoscale
           .with(body: JSON.generate(expected_body))
 
         Reporter.instance.run_metrics_collection Config.instance, [web_metrics_collector, job_metrics_collector]
-
-        assert_requested stub
-      end
-
-      it "only sends an empty (no metrics) report one time" do
-        metrics_collector = Test::TestEmptyMetricsCollector.new
-
-        expected_body = Report.new(Judoscale.adapters, Config.instance, metrics_collector.collect).as_json
-        stub = stub_request(:post, "http://example.com/api/test-token/v3/reports")
-          .with(body: JSON.generate(expected_body)).to_return({status: 200}).times(1)
-
-        Reporter.instance.run_metrics_collection Config.instance, [metrics_collector]
-        Reporter.instance.run_metrics_collection Config.instance, [metrics_collector]
 
         assert_requested stub
       end

--- a/judoscale-ruby/test/test_helper.rb
+++ b/judoscale-ruby/test/test_helper.rb
@@ -27,12 +27,6 @@ module Judoscale
         [Metric.new(:qt, 1, Time.now)]
       end
     end
-
-    class TestEmptyMetricsCollector < Judoscale::WebMetricsCollector
-      def collect
-        []
-      end
-    end
   end
 
   add_adapter :test_web, {}, metrics_collector: Test::TestWebMetricsCollector


### PR DESCRIPTION
This reverts commit 0835f53e615350f432be9d7e759c7ec8327cf829.

Our downscaling logic will suppress downscaling if there are no reports, so it's important that we continually report even if there are no metrics.

Not sure why the original "perf" improvement was made. There's almost no perf gain by skipping the reports.