### PR TITLE
Update and shorten gem summaries

### DIFF
--- a/judoscale-delayed_job/judoscale-delayed_job.gemspec
+++ b/judoscale-delayed_job/judoscale-delayed_job.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides DelayedJob integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Delayed Job workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-delayed_job/rails-autoscale-delayed_job.gemspec
+++ b/judoscale-delayed_job/rails-autoscale-delayed_job.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides DelayedJob integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Delayed Job workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-good_job/judoscale-good_job.gemspec
+++ b/judoscale-good_job/judoscale-good_job.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides GoodJob integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Good Job workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-good_job/rails-autoscale-good_job.gemspec
+++ b/judoscale-good_job/rails-autoscale-good_job.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides GoodJob integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Good Job workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-que/judoscale-que.gemspec
+++ b/judoscale-que/judoscale-que.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Que integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Que workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-que/rails-autoscale-que.gemspec
+++ b/judoscale-que/rails-autoscale-que.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Que integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Que workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-rack/judoscale-rack.gemspec
+++ b/judoscale-rack/judoscale-rack.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Rack app integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Rack applications."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-rack/rails-autoscale-rack.gemspec
+++ b/judoscale-rack/rails-autoscale-rack.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Rack app integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Rack applications."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-rails/judoscale-rails.gemspec
+++ b/judoscale-rails/judoscale-rails.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Ruby on Rails integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Ruby on Rails applications."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-rails/rails-autoscale-web.gemspec
+++ b/judoscale-rails/rails-autoscale-web.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Ruby on Rails integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Ruby on Rails applications."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-resque/judoscale-resque.gemspec
+++ b/judoscale-resque/judoscale-resque.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Resque integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Resque workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-resque/rails-autoscale-resque.gemspec
+++ b/judoscale-resque/rails-autoscale-resque.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Resque integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Resque workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-ruby/judoscale-ruby.gemspec
+++ b/judoscale-ruby/judoscale-ruby.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem works with the Judoscale Heroku add-on to automatically scale your web and worker dynos."
+  spec.summary = "Autoscaling for Ruby."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-ruby/rails-autoscale-core.gemspec
+++ b/judoscale-ruby/rails-autoscale-core.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem works with the Judoscale Heroku add-on to automatically scale your web and worker dynos."
+  spec.summary = "Autoscaling for Ruby."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-shoryuken/judoscale-shoryuken.gemspec
+++ b/judoscale-shoryuken/judoscale-shoryuken.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Shoryuken integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Shoryuken workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-shoryuken/rails-autoscale-shoryuken.gemspec
+++ b/judoscale-shoryuken/rails-autoscale-shoryuken.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Shoryuken integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Shoryuken workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-sidekiq/judoscale-sidekiq.gemspec
+++ b/judoscale-sidekiq/judoscale-sidekiq.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Sidekiq integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Sidekiq workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-sidekiq/rails-autoscale-sidekiq.gemspec
+++ b/judoscale-sidekiq/rails-autoscale-sidekiq.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides Sidekiq integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Sidekiq workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-solid_queue/judoscale-solid_queue.gemspec
+++ b/judoscale-solid_queue/judoscale-solid_queue.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides SolidQueue integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Solid Queue workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 

--- a/judoscale-solid_queue/rails-autoscale-solid_queue.gemspec
+++ b/judoscale-solid_queue/rails-autoscale-solid_queue.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Adam McCrea", "Carlos Antonio da Silva", "Jon Sullivan"]
   spec.email = ["hello@judoscale.com"]
 
-  spec.summary = "This gem provides SolidQueue integration with the Judoscale autoscaling add-on for Heroku."
+  spec.summary = "Autoscaling for Solid Queue workers."
   spec.homepage = "https://judoscale.com"
   spec.license = "MIT"
 


### PR DESCRIPTION
Remove specific mention of "Heroku add-on", simplify and make them short and sweet.

Ref: https://github.com/judoscale/judoscale-ruby/pull/204#discussion_r1587547531