### PR TITLE
Setup steps after release-please to automate gem version syncing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,26 @@ jobs:
           bump-minor-pre-major: true
           version-file: "judoscale-ruby/lib/judoscale/version.rb"
 
+      - name: Sync versions - checkout code
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@v4
+
+      - name: Sync versions - setup Ruby
+        if: ${{ steps.release.outputs.release_created }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+
+      - name: Sync versions
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          bin/sync-versions
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add .
+          git commit -m "Sync versions"
+          git push
+
   publish:
     name: Publish to Rubygems
     needs: release-please
@@ -29,12 +49,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.2
+          ruby-version: 3.3
 
       - name: Publish gems
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Sync versions - checkout code
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release.outputs.pr.headBranchName }}
 
       - name: Sync versions - setup Ruby
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
This is an attempt to automatically sync our gem versions after release-please detects the need to bump the version. It will open up a PR with that new version bump to judoscale-ruby and changelog added, and these extra steps should follow-up that with syncing the new version across the other libraries.

I have done some manual testing on this using a separate branch, by commenting out the release-please and "if" statements, and only triggering these actual steps that sync versions and push a new commit. By bumping the judoscale-ruby version myself in a commit, the automated steps here would generate a new follow-up commit automatically syncing the other gems versions, so I'm hopeful this will work as expected. (famous last words)

![Screenshot 2024-05-03 at 13 23 57](https://github.com/judoscale/judoscale-ruby/assets/26328/864eab51-d4cb-451b-bc4d-bc85db41daa5)

The git user name/email and commands in general are based on examples:
https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token 
https://github.com/google-github-actions/release-please-action/tree/v3.7.13?tab=readme-ov-file#creating-majorminor-tags

---

Here's my original message sharing the steps I took for testing, for reference:

> I pushed a [commit with those steps to a branch](https://github.com/judoscale/judoscale-ruby/commit/c870327d7a1a2f4c74192404a60abffc0de6836d), commenting out the rest of the release-please stuff, and updating the version, and it [added a new commit syncing correctly](https://github.com/judoscale/judoscale-ruby/commit/f98120dfd168543ae4be6e0ab32b7302c01ed3bf). I pushed [one more version bump](https://github.com/judoscale/judoscale-ruby/commit/33174ac64b7a15ad0907795e32391a83f1291687) alone, and [it synced](https://github.com/judoscale/judoscale-ruby/commit/459d14206cf76cd70fb429039294f457d6d63910) again. Here's the [latest action that synced](https://github.com/judoscale/judoscale-ruby/actions/runs/8941996325/job/24563601644).
>
> Another idea I was contemplating was to try a pre-commit hook, but since this is just running on those release PRs, and we'll squash the commits anyway, this might be all we need.