### PR TITLE
Make rails-autoscale-* gems wrappers around judoscale-*, simplify requires & gemspecs

### DIFF
--- a/judoscale-delayed_job/judoscale-delayed_job.gemspec
+++ b/judoscale-delayed_job/judoscale-delayed_job.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/delayed_job/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/delayed_job/version"
 
 Gem::Specification.new do |spec|
   spec.name = "judoscale-delayed_job"

--- a/judoscale-delayed_job/judoscale-delayed_job.gemspec
+++ b/judoscale-delayed_job/judoscale-delayed_job.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-delayed_job/lib/rails-autoscale-delayed_job.rb
+++ b/judoscale-delayed_job/lib/rails-autoscale-delayed_job.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "judoscale/delayed_job"
+require "judoscale-delayed_job"

--- a/judoscale-delayed_job/rails-autoscale-delayed_job.gemspec
+++ b/judoscale-delayed_job/rails-autoscale-delayed_job.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
+  spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-delayed_job/rails-autoscale-delayed_job.gemspec
+++ b/judoscale-delayed_job/rails-autoscale-delayed_job.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
-
   spec.add_dependency "judoscale-delayed_job", Judoscale::DelayedJob::VERSION
 end

--- a/judoscale-delayed_job/rails-autoscale-delayed_job.gemspec
+++ b/judoscale-delayed_job/rails-autoscale-delayed_job.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/delayed_job/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/delayed_job/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-autoscale-delayed_job"

--- a/judoscale-delayed_job/rails-autoscale-delayed_job.gemspec
+++ b/judoscale-delayed_job/rails-autoscale-delayed_job.gemspec
@@ -20,11 +20,10 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_dependency "rails-autoscale-core", Judoscale::DelayedJob::VERSION
-  spec.add_dependency "delayed_job_active_record", ">= 4.0"
+  spec.add_dependency "judoscale-delayed_job", Judoscale::DelayedJob::VERSION
 end

--- a/judoscale-good_job/judoscale-good_job.gemspec
+++ b/judoscale-good_job/judoscale-good_job.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-good_job/judoscale-good_job.gemspec
+++ b/judoscale-good_job/judoscale-good_job.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/good_job/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/good_job/version"
 
 Gem::Specification.new do |spec|
   spec.name = "judoscale-good_job"

--- a/judoscale-good_job/lib/rails-autoscale-good_job.rb
+++ b/judoscale-good_job/lib/rails-autoscale-good_job.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "judoscale/good_job"
+require "judoscale-good_job"

--- a/judoscale-good_job/rails-autoscale-good_job.gemspec
+++ b/judoscale-good_job/rails-autoscale-good_job.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/good_job/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/good_job/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-autoscale-good_job"

--- a/judoscale-good_job/rails-autoscale-good_job.gemspec
+++ b/judoscale-good_job/rails-autoscale-good_job.gemspec
@@ -20,11 +20,10 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_dependency "rails-autoscale-core", Judoscale::GoodJob::VERSION
-  spec.add_dependency "good_job", ">= 3.0"
+  spec.add_dependency "judoscale-good_job", Judoscale::GoodJob::VERSION
 end

--- a/judoscale-good_job/rails-autoscale-good_job.gemspec
+++ b/judoscale-good_job/rails-autoscale-good_job.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
+  spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-good_job/rails-autoscale-good_job.gemspec
+++ b/judoscale-good_job/rails-autoscale-good_job.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
-
   spec.add_dependency "judoscale-good_job", Judoscale::GoodJob::VERSION
 end

--- a/judoscale-que/judoscale-que.gemspec
+++ b/judoscale-que/judoscale-que.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/que/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/que/version"
 
 Gem::Specification.new do |spec|
   spec.name = "judoscale-que"

--- a/judoscale-que/judoscale-que.gemspec
+++ b/judoscale-que/judoscale-que.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-que/lib/rails-autoscale-que.rb
+++ b/judoscale-que/lib/rails-autoscale-que.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "judoscale/que"
+require "judoscale-que"

--- a/judoscale-que/rails-autoscale-que.gemspec
+++ b/judoscale-que/rails-autoscale-que.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
-
   spec.add_dependency "judoscale-que", Judoscale::Que::VERSION
 end

--- a/judoscale-que/rails-autoscale-que.gemspec
+++ b/judoscale-que/rails-autoscale-que.gemspec
@@ -20,11 +20,10 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_dependency "rails-autoscale-core", Judoscale::Que::VERSION
-  spec.add_dependency "que", ">= 1.0"
+  spec.add_dependency "judoscale-que", Judoscale::Que::VERSION
 end

--- a/judoscale-que/rails-autoscale-que.gemspec
+++ b/judoscale-que/rails-autoscale-que.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
+  spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-que/rails-autoscale-que.gemspec
+++ b/judoscale-que/rails-autoscale-que.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/que/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/que/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-autoscale-que"

--- a/judoscale-rack/judoscale-rack.gemspec
+++ b/judoscale-rack/judoscale-rack.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/rack/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/rack/version"
 
 Gem::Specification.new do |spec|
   spec.name = "judoscale-rack"

--- a/judoscale-rack/judoscale-rack.gemspec
+++ b/judoscale-rack/judoscale-rack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-rack/lib/rails-autoscale-rack.rb
+++ b/judoscale-rack/lib/rails-autoscale-rack.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "judoscale/rack"
+require "judoscale-rack"

--- a/judoscale-rack/rails-autoscale-rack.gemspec
+++ b/judoscale-rack/rails-autoscale-rack.gemspec
@@ -20,11 +20,10 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_dependency "rails-autoscale-core", Judoscale::Rack::VERSION
-  spec.add_dependency "rack"
+  spec.add_dependency "judoscale-rack", Judoscale::Rack::VERSION
 end

--- a/judoscale-rack/rails-autoscale-rack.gemspec
+++ b/judoscale-rack/rails-autoscale-rack.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/rack/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/rack/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-autoscale-rack"

--- a/judoscale-rack/rails-autoscale-rack.gemspec
+++ b/judoscale-rack/rails-autoscale-rack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
+  spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-rack/rails-autoscale-rack.gemspec
+++ b/judoscale-rack/rails-autoscale-rack.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
-
   spec.add_dependency "judoscale-rack", Judoscale::Rack::VERSION
 end

--- a/judoscale-rails/judoscale-rails.gemspec
+++ b/judoscale-rails/judoscale-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-rails/judoscale-rails.gemspec
+++ b/judoscale-rails/judoscale-rails.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/rails/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/rails/version"
 
 Gem::Specification.new do |spec|
   spec.name = "judoscale-rails"

--- a/judoscale-rails/lib/rails-autoscale-web.rb
+++ b/judoscale-rails/lib/rails-autoscale-web.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "judoscale/rails"
+require "judoscale-rails"

--- a/judoscale-rails/rails-autoscale-web.gemspec
+++ b/judoscale-rails/rails-autoscale-web.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
+  spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-rails/rails-autoscale-web.gemspec
+++ b/judoscale-rails/rails-autoscale-web.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/rails/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/rails/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-autoscale-web"

--- a/judoscale-rails/rails-autoscale-web.gemspec
+++ b/judoscale-rails/rails-autoscale-web.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
-
   spec.add_dependency "judoscale-rails", Judoscale::Rails::VERSION
 end

--- a/judoscale-rails/rails-autoscale-web.gemspec
+++ b/judoscale-rails/rails-autoscale-web.gemspec
@@ -20,11 +20,10 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_dependency "rails-autoscale-core", Judoscale::Rails::VERSION
-  spec.add_dependency "railties"
+  spec.add_dependency "judoscale-rails", Judoscale::Rails::VERSION
 end

--- a/judoscale-resque/judoscale-resque.gemspec
+++ b/judoscale-resque/judoscale-resque.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/resque/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/resque/version"
 
 Gem::Specification.new do |spec|
   spec.name = "judoscale-resque"

--- a/judoscale-resque/judoscale-resque.gemspec
+++ b/judoscale-resque/judoscale-resque.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-resque/lib/rails-autoscale-resque.rb
+++ b/judoscale-resque/lib/rails-autoscale-resque.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "judoscale/resque"
+require "judoscale-resque"

--- a/judoscale-resque/rails-autoscale-resque.gemspec
+++ b/judoscale-resque/rails-autoscale-resque.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/resque/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/resque/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-autoscale-resque"

--- a/judoscale-resque/rails-autoscale-resque.gemspec
+++ b/judoscale-resque/rails-autoscale-resque.gemspec
@@ -20,11 +20,10 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_dependency "rails-autoscale-core", Judoscale::Resque::VERSION
-  spec.add_dependency "resque", ">= 2.0"
+  spec.add_dependency "judoscale-resque", Judoscale::Resque::VERSION
 end

--- a/judoscale-resque/rails-autoscale-resque.gemspec
+++ b/judoscale-resque/rails-autoscale-resque.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
+  spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-resque/rails-autoscale-resque.gemspec
+++ b/judoscale-resque/rails-autoscale-resque.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
-
   spec.add_dependency "judoscale-resque", Judoscale::Resque::VERSION
 end

--- a/judoscale-ruby/judoscale-ruby.gemspec
+++ b/judoscale-ruby/judoscale-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-ruby/judoscale-ruby.gemspec
+++ b/judoscale-ruby/judoscale-ruby.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/version"
 
 Gem::Specification.new do |spec|
   spec.name = "judoscale-ruby"

--- a/judoscale-ruby/rails-autoscale-core.gemspec
+++ b/judoscale-ruby/rails-autoscale-core.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
-
   spec.add_dependency "judoscale-ruby", Judoscale::VERSION
 end

--- a/judoscale-ruby/rails-autoscale-core.gemspec
+++ b/judoscale-ruby/rails-autoscale-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
+  spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-ruby/rails-autoscale-core.gemspec
+++ b/judoscale-ruby/rails-autoscale-core.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-autoscale-core"

--- a/judoscale-ruby/rails-autoscale-core.gemspec
+++ b/judoscale-ruby/rails-autoscale-core.gemspec
@@ -20,8 +20,10 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"
+
+  spec.add_dependency "judoscale-ruby", Judoscale::VERSION
 end

--- a/judoscale-shoryuken/judoscale-shoryuken.gemspec
+++ b/judoscale-shoryuken/judoscale-shoryuken.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-shoryuken/judoscale-shoryuken.gemspec
+++ b/judoscale-shoryuken/judoscale-shoryuken.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/shoryuken/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/shoryuken/version"
 
 Gem::Specification.new do |spec|
   spec.name = "judoscale-shoryuken"

--- a/judoscale-shoryuken/lib/rails-autoscale-shoryuken.rb
+++ b/judoscale-shoryuken/lib/rails-autoscale-shoryuken.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "judoscale/shoryuken"
+require "judoscale-shoryuken"

--- a/judoscale-shoryuken/rails-autoscale-shoryuken.gemspec
+++ b/judoscale-shoryuken/rails-autoscale-shoryuken.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
+  spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-shoryuken/rails-autoscale-shoryuken.gemspec
+++ b/judoscale-shoryuken/rails-autoscale-shoryuken.gemspec
@@ -20,11 +20,10 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_dependency "rails-autoscale-core", Judoscale::Shoryuken::VERSION
-  spec.add_dependency "shoryuken", ">= 6.0"
+  spec.add_dependency "judoscale-shoryuken", Judoscale::Shoryuken::VERSION
 end

--- a/judoscale-shoryuken/rails-autoscale-shoryuken.gemspec
+++ b/judoscale-shoryuken/rails-autoscale-shoryuken.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/shoryuken/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/shoryuken/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-autoscale-shoryuken"

--- a/judoscale-shoryuken/rails-autoscale-shoryuken.gemspec
+++ b/judoscale-shoryuken/rails-autoscale-shoryuken.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
-
   spec.add_dependency "judoscale-shoryuken", Judoscale::Shoryuken::VERSION
 end

--- a/judoscale-sidekiq/judoscale-sidekiq.gemspec
+++ b/judoscale-sidekiq/judoscale-sidekiq.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-sidekiq/judoscale-sidekiq.gemspec
+++ b/judoscale-sidekiq/judoscale-sidekiq.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/sidekiq/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/sidekiq/version"
 
 Gem::Specification.new do |spec|
   spec.name = "judoscale-sidekiq"

--- a/judoscale-sidekiq/lib/rails-autoscale-sidekiq.rb
+++ b/judoscale-sidekiq/lib/rails-autoscale-sidekiq.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "judoscale/sidekiq"
+require "judoscale-sidekiq"

--- a/judoscale-sidekiq/rails-autoscale-sidekiq.gemspec
+++ b/judoscale-sidekiq/rails-autoscale-sidekiq.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
+  spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/judoscale-sidekiq/rails-autoscale-sidekiq.gemspec
+++ b/judoscale-sidekiq/rails-autoscale-sidekiq.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/sidekiq/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/sidekiq/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-autoscale-sidekiq"

--- a/judoscale-sidekiq/rails-autoscale-sidekiq.gemspec
+++ b/judoscale-sidekiq/rails-autoscale-sidekiq.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
-
   spec.add_dependency "judoscale-sidekiq", Judoscale::Sidekiq::VERSION
 end

--- a/judoscale-sidekiq/rails-autoscale-sidekiq.gemspec
+++ b/judoscale-sidekiq/rails-autoscale-sidekiq.gemspec
@@ -20,11 +20,10 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_dependency "rails-autoscale-core", Judoscale::Sidekiq::VERSION
-  spec.add_dependency "sidekiq", ">= 5.0"
+  spec.add_dependency "judoscale-sidekiq", Judoscale::Sidekiq::VERSION
 end

--- a/judoscale-solid_queue/judoscale-solid_queue.gemspec
+++ b/judoscale-solid_queue/judoscale-solid_queue.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/solid_queue/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/solid_queue/version"
 
 Gem::Specification.new do |spec|
   spec.name = "judoscale-solid_queue"

--- a/judoscale-solid_queue/judoscale-solid_queue.gemspec
+++ b/judoscale-solid_queue/judoscale-solid_queue.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.7.0"

--- a/judoscale-solid_queue/lib/rails-autoscale-solid_queue.rb
+++ b/judoscale-solid_queue/lib/rails-autoscale-solid_queue.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "judoscale/solid_queue"
+require "judoscale-solid_queue"

--- a/judoscale-solid_queue/rails-autoscale-solid_queue.gemspec
+++ b/judoscale-solid_queue/rails-autoscale-solid_queue.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7.0"
-
   spec.add_dependency "judoscale-solid_queue", Judoscale::SolidQueue::VERSION
 end

--- a/judoscale-solid_queue/rails-autoscale-solid_queue.gemspec
+++ b/judoscale-solid_queue/rails-autoscale-solid_queue.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
+  spec.files = Dir["lib/**/*"].select { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.7.0"

--- a/judoscale-solid_queue/rails-autoscale-solid_queue.gemspec
+++ b/judoscale-solid_queue/rails-autoscale-solid_queue.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "judoscale/solid_queue/version"
+# frozen_string_literal: true
+
+require_relative "lib/judoscale/solid_queue/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-autoscale-solid_queue"

--- a/judoscale-solid_queue/rails-autoscale-solid_queue.gemspec
+++ b/judoscale-solid_queue/rails-autoscale-solid_queue.gemspec
@@ -20,11 +20,10 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/judoscale/judoscale-ruby"
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").select { |f| f.match?(%r{rails-autoscale|version.rb}) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.7.0"
 
-  spec.add_dependency "rails-autoscale-core", Judoscale::SolidQueue::VERSION
-  spec.add_dependency "solid_queue", ">= 0.3"
+  spec.add_dependency "judoscale-solid_queue", Judoscale::SolidQueue::VERSION
 end


### PR DESCRIPTION
This simplifies our gem setup to avoid getting judoscale-* and rails-autoscale-* out of sync. This happened recently with good job: https://github.com/judoscale/judoscale-ruby/pull/198.

Changes:

- Make `rails-autoscale-*` depend on their respective `judoscale-*` library, leaving `judoscale-*` handle any additional dependencies.
- Similarly, remove the Ruby version requirement from `rails-autoscale-*`, since it should honor `judoscale-*`.
- `rails-autoscale-*` do not require the `rails-autoscale-core` library anymore, since it should have access to the core via `judoscale-*` -> `judoscale-ruby`, and the constant aliasing is there in judoscale-ruby.
- Each library will only include their respective `lib/*` files, no longer include Gemfile(s)/Rakefile/gemspec(s).
  - `rails-autoscale-*` will simply include `lib/rails-autoscale-*`, and that will require the respective `judoscale-*` lib now
  - `judoscale-*` will include everything under `lib/*`, except files matching `rails-autoscale`
  - it's essentially partitioning the `lib/*` files between the two libs.