### PR TITLE
Mark the reporter thread as "fork safe" to avoid warnings

### DIFF
--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -46,6 +46,9 @@ module Judoscale
 
     def run_loop(config, metrics_collectors)
       @_thread = Thread.new do
+        # Advise multi-threaded app servers to ignore this thread for the purposes of fork safety warnings.
+        Thread.current.thread_variable_set(:fork_safe, true)
+
         loop do
           run_metrics_collection(config, metrics_collectors)
 


### PR DESCRIPTION
This prevents the Reporter thread from generating warnings with puma, which has been warning on any threads created before forking.

The Reporter thread is aware of forking by keeping the current `pid` around, and initializing another thread if the `pid` changes. It means we still have a running Reporter on the main puma process in this case, plus one for each forked process (if running in cluster mode, in case of puma.)

References:
https://github.com/rails/rails/pull/40399
https://github.com/puma/puma/pull/2475
https://github.com/puma/puma/releases/tag/v5.1.0

Closes #170