### PR TITLE
Skip starting Judoscale reporter on `rails runner` process

### DIFF
--- a/judoscale-rails/lib/judoscale/rails/railtie.rb
+++ b/judoscale-rails/lib/judoscale/rails/railtie.rb
@@ -12,9 +12,9 @@ module Judoscale
     class Railtie < ::Rails::Railtie
       include Judoscale::Logger
 
-      def in_rails_console?
-        # This is gross, but we can't find a more reliable way to detect if we're in a Rails console.
-        caller.any? { |call| call.include?("console_command.rb") }
+      def in_rails_console_or_runner?
+        # This is gross, but we can't find a more reliable way to detect if we're in a Rails console/runner.
+        caller.any? { |call| call.include?("console_command.rb") || call.include?("runner_command.rb") }
       end
 
       def in_rake_task?(task_regex)
@@ -36,8 +36,8 @@ module Judoscale
       end
 
       config.after_initialize do
-        if in_rails_console?
-          logger.debug "No reporting since we're in a Rails console"
+        if in_rails_console_or_runner?
+          logger.debug "No reporting since we're in a Rails console or runner process"
         elsif in_rake_task?(/assets:|db:/)
           logger.debug "No reporting since we're in a build process"
         elsif judoscale_config.start_reporter_after_initialize


### PR DESCRIPTION
Similar to when running the `rails console`, we want to skip the reporter on `rails runner` to prevent it initializing another background thread and triggering an API call to our backend when executing one-off commands via the runner.

console: https://github.com/rails/rails/blob/a2f2dc8afd38b2d4ebd0170a75be2910fd7e4e45/railties/lib/rails/commands/console/console_command.rb
runner: https://github.com/rails/rails/blob/a2f2dc8afd38b2d4ebd0170a75be2910fd7e4e45/railties/lib/rails/commands/runner/runner_command.rb
