### PR TITLE
chore: Enforce version constraint for standard linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,12 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.3'
+          - "3.3"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: gem install standard
+      - run: gem install standard -v '~> 1.40.0'
       - run: standardrb


### PR DESCRIPTION
v1.41.0 has enabled the RedundantInterpolationUnfreeze rule, which is not supported in Ruby 2.x. Until our gem drops support for Ruby 2.x, we need our linter to respect it.