### PR TITLE
Add specific worker backend notes and table with collected metrics for each backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,15 @@ Judoscale aggregates and stores this information to power the autoscaler algorit
 
 ### What data is collected for each worker adapter?
 
-| adapter               | queue time | queue depth | busy |
-|-----------------------|------------|-------------|------|
-| judoscale-sidekiq     | ✅         | ✅          | ✅   |
-| judoscale-solid_queue | ✅         | ❌          | ✅   |
-| judoscale-resque      | ✅         | ✅          | ✅   |
-| judoscale-delayed_job | ✅         | ❌          | ✅   |
-| judoscale-good_job    | ✅         | ❌          | ✅   |
-| judoscale-que         | ✅         | ❌          | ✅   |
-| judoscale-shoryuken   | ❌         | ✅          | ❌   |
+| adapter               | queue time | queue depth | busy (if enabled) |
+|-----------------------|------------|-------------|-------------------|
+| judoscale-sidekiq     | ✅         | ✅          | ✅                |
+| judoscale-solid_queue | ✅         | ❌          | ✅                |
+| judoscale-resque      | ✅         | ✅          | ✅                |
+| judoscale-delayed_job | ✅         | ❌          | ✅                |
+| judoscale-good_job    | ✅         | ❌          | ✅                |
+| judoscale-que         | ✅         | ❌          | ✅                |
+| judoscale-shoryuken   | ❌         | ✅          | ❌                |
 
 ## Migrating from `rails_autoscale_agent`
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For most apps, no additional configuration is needed. See the [configuration](#c
 
 Note that if you aren't using Rails, you'll need to start the reporter manually. See below.
 
-### Specific backend notes
+### Specific worker backend notes
 
 #### Resque
 
@@ -99,9 +99,22 @@ The reporter runs in its own thread so your web requests and background jobs are
 - Judoscale gem versions
 - Dyno name (example: web.1)
 - PID
-- Collection of queue time metrics (time and milliseconds)
+- Collection of queue time metrics (time and milliseconds) for web
+- Collection of queue time and/or queue depth metrics, and busy metrics (if enabled), for workers (see below)
 
 Judoscale aggregates and stores this information to power the autoscaler algorithm and dashboard visualizations.
+
+### What data is collected for each worker adapter?
+
+| adapter               | queue time | queue depth | busy |
+|-----------------------|------------|-------------|------|
+| judoscale-sidekiq     | ✅         | ✅          | ✅   |
+| judoscale-solid_queue | ✅         | ❌          | ✅   |
+| judoscale-resque      | ✅         | ✅          | ✅   |
+| judoscale-delayed_job | ✅         | ❌          | ✅   |
+| judoscale-good_job    | ✅         | ❌          | ✅   |
+| judoscale-que         | ✅         | ❌          | ✅   |
+| judoscale-shoryuken   | ❌         | ✅          | ❌   |
 
 ## Migrating from `rails_autoscale_agent`
 

--- a/README.md
+++ b/README.md
@@ -108,13 +108,13 @@ Judoscale aggregates and stores this information to power the autoscaler algorit
 
 | adapter               | queue time | queue depth | busy (if enabled) |
 |-----------------------|------------|-------------|-------------------|
-| judoscale-sidekiq     | ✅         | ✅          | ✅                |
-| judoscale-solid_queue | ✅         | ❌          | ✅                |
-| judoscale-resque      | ✅         | ✅          | ✅                |
-| judoscale-delayed_job | ✅         | ❌          | ✅                |
-| judoscale-good_job    | ✅         | ❌          | ✅                |
-| judoscale-que         | ✅         | ❌          | ✅                |
-| judoscale-shoryuken   | ❌         | ✅          | ❌                |
+| judoscale-sidekiq     | ✅         | ✅          | ✅               |
+| judoscale-solid_queue | ✅         | ❌          | ✅               |
+| judoscale-resque      | ✅         | ✅          | ✅               |
+| judoscale-delayed_job | ✅         | ❌          | ✅               |
+| judoscale-good_job    | ✅         | ❌          | ✅               |
+| judoscale-que         | ✅         | ❌          | ✅               |
+| judoscale-shoryuken   | ❌         | ✅          | ❌               |
 
 ## Migrating from `rails_autoscale_agent`
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ For most apps, no additional configuration is needed. See the [configuration](#c
 
 Note that if you aren't using Rails, you'll need to start the reporter manually. See below.
 
+### Specific backend notes
+
+#### Resque
+
+If you're using `resque-scheduler` and their [standalone executable](https://github.com/resque/resque-scheduler?tab=readme-ov-file#standalone-executable) approach, make sure to add a `require "judoscale-resque"` to your executable, or require your entire Rails application, to make sure the Judoscale extension that stores latency for each job gets properly loaded within the scheduler process, otherwise metrics may not be reported appropriately from the scheduler.
+
 ## Worker-only apps
 
 If your app doesn't have a web process, you don't _have_ to include the "judoscale-rails" gem. If you omit it, you'll need to start the reporter manually:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Note that if you aren't using Rails, you'll need to start the reporter manually.
 
 #### Resque
 
-If you're using `resque-scheduler` and their [standalone executable](https://github.com/resque/resque-scheduler?tab=readme-ov-file#standalone-executable) approach, make sure to add a `require "judoscale-resque"` to your executable, or require your entire Rails application, to make sure the Judoscale extension that stores latency for each job gets properly loaded within the scheduler process, otherwise metrics may not be reported appropriately from the scheduler.
+If you're using `resque-scheduler` and their [standalone executable](https://github.com/resque/resque-scheduler?tab=readme-ov-file#standalone-executable) approach, add a `require "judoscale-resque"` to your executable, or require your entire Rails application. This ensures the Judoscale extension that stores latency for each job gets properly loaded within the scheduler process, otherwise metrics may not be reported appropriately from the scheduler.
 
 ## Worker-only apps
 

--- a/sample-apps/delayed_job-sample/Gemfile.lock
+++ b/sample-apps/delayed_job-sample/Gemfile.lock
@@ -1,44 +1,44 @@
 PATH
   remote: ../../judoscale-delayed_job
   specs:
-    judoscale-delayed_job (1.8.1)
+    judoscale-delayed_job (1.8.2)
       delayed_job_active_record (>= 4.0)
-      judoscale-ruby (= 1.8.1)
+      judoscale-ruby (= 1.8.2)
 
 PATH
   remote: ../../judoscale-rails
   specs:
-    judoscale-rails (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-rails (1.8.2)
+      judoscale-ruby (= 1.8.2)
       railties
 
 PATH
   remote: ../../judoscale-ruby
   specs:
-    judoscale-ruby (1.8.1)
+    judoscale-ruby (1.8.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.0.8.5)
-      actionview (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionpack (7.0.8.6)
+      actionview (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionview (7.0.8.6)
+      activesupport (= 7.0.8.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activemodel (7.0.8.5)
-      activesupport (= 7.0.8.5)
-    activerecord (7.0.8.5)
-      activemodel (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
-    activesupport (7.0.8.5)
+    activemodel (7.0.8.6)
+      activesupport (= 7.0.8.6)
+    activerecord (7.0.8.6)
+      activemodel (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
+    activesupport (7.0.8.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -60,21 +60,21 @@ GEM
     erubi (1.13.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    loofah (2.22.0)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
     minitest (5.25.1)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
-    pg (1.5.8)
+    pg (1.5.9)
     puma (5.6.9)
       nio4r (~> 2.0)
     racc (1.8.1)
@@ -91,9 +91,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.0.8.5)
-      actionpack (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    railties (7.0.8.6)
+      actionpack (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -109,13 +109,14 @@ GEM
     tilt (2.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.7.0)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 

--- a/sample-apps/good_job-multi-db-sample/Gemfile.lock
+++ b/sample-apps/good_job-multi-db-sample/Gemfile.lock
@@ -1,53 +1,53 @@
 PATH
   remote: ../../judoscale-good_job
   specs:
-    judoscale-good_job (1.8.1)
+    judoscale-good_job (1.8.2)
       good_job (>= 3.0, < 5.0)
-      judoscale-ruby (= 1.8.1)
+      judoscale-ruby (= 1.8.2)
 
 PATH
   remote: ../../judoscale-rails
   specs:
-    judoscale-rails (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-rails (1.8.2)
+      judoscale-ruby (= 1.8.2)
       railties
 
 PATH
   remote: ../../judoscale-ruby
   specs:
-    judoscale-ruby (1.8.1)
+    judoscale-ruby (1.8.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.0.8.4)
-      actionview (= 7.0.8.4)
-      activesupport (= 7.0.8.4)
+    actionpack (7.0.8.6)
+      actionview (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.8.4)
-      activesupport (= 7.0.8.4)
+    actionview (7.0.8.6)
+      activesupport (= 7.0.8.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (7.0.8.4)
-      activesupport (= 7.0.8.4)
+    activejob (7.0.8.6)
+      activesupport (= 7.0.8.6)
       globalid (>= 0.3.6)
-    activemodel (7.0.8.4)
-      activesupport (= 7.0.8.4)
-    activerecord (7.0.8.4)
-      activemodel (= 7.0.8.4)
-      activesupport (= 7.0.8.4)
-    activesupport (7.0.8.4)
+    activemodel (7.0.8.6)
+      activesupport (= 7.0.8.6)
+    activerecord (7.0.8.6)
+      activemodel (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
+    activesupport (7.0.8.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     builder (3.3.0)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     crass (1.0.6)
     debug (1.9.2)
       irb (~> 1.10)
@@ -55,44 +55,44 @@ GEM
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
-    fugit (1.11.0)
+    fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    good_job (3.99.0)
+    good_job (3.99.1)
       activejob (>= 6.0.0)
       activerecord (>= 6.0.0)
       concurrent-ruby (>= 1.0.2)
       fugit (>= 1.1)
       railties (>= 6.0.0)
       thor (>= 0.14.1)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
-    irb (1.12.0)
-      rdoc
+    irb (1.14.1)
+      rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    loofah (2.22.0)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
-    minitest (5.24.1)
-    nio4r (2.7.1)
-    nokogiri (1.16.6-arm64-darwin)
+    minitest (5.25.1)
+    nio4r (2.7.4)
+    nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-darwin)
+    nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-linux)
+    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
-    pg (1.5.6)
+    pg (1.5.9)
     psych (5.1.2)
       stringio
-    puma (5.6.8)
+    puma (5.6.9)
       nio4r (~> 2.0)
     raabro (1.4.0)
-    racc (1.8.0)
-    rack (2.2.9)
+    racc (1.8.1)
+    rack (2.2.10)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails-dom-testing (2.2.0)
@@ -102,29 +102,30 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.0.8.4)
-      actionpack (= 7.0.8.4)
-      activesupport (= 7.0.8.4)
+    railties (7.0.8.6)
+      actionpack (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.2.1)
-    rdoc (6.6.3.1)
+    rdoc (6.7.0)
       psych (>= 4.0.0)
-    reline (0.5.4)
+    reline (0.5.10)
       io-console (~> 0.5)
-    stringio (3.1.0)
-    thor (1.3.1)
+    stringio (3.1.1)
+    thor (1.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.16)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 
@@ -144,4 +145,4 @@ DEPENDENCIES
   railties (~> 7.0.1)
 
 BUNDLED WITH
-   2.5.11
+   2.5.22

--- a/sample-apps/good_job-sample/Gemfile.lock
+++ b/sample-apps/good_job-sample/Gemfile.lock
@@ -1,47 +1,47 @@
 PATH
   remote: ../../judoscale-good_job
   specs:
-    judoscale-good_job (1.8.1)
+    judoscale-good_job (1.8.2)
       good_job (>= 3.0, < 5.0)
-      judoscale-ruby (= 1.8.1)
+      judoscale-ruby (= 1.8.2)
 
 PATH
   remote: ../../judoscale-rails
   specs:
-    judoscale-rails (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-rails (1.8.2)
+      judoscale-ruby (= 1.8.2)
       railties
 
 PATH
   remote: ../../judoscale-ruby
   specs:
-    judoscale-ruby (1.8.1)
+    judoscale-ruby (1.8.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.0.8.5)
-      actionview (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionpack (7.0.8.6)
+      actionview (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionview (7.0.8.6)
+      activesupport (= 7.0.8.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (7.0.8.5)
-      activesupport (= 7.0.8.5)
+    activejob (7.0.8.6)
+      activesupport (= 7.0.8.6)
       globalid (>= 0.3.6)
-    activemodel (7.0.8.5)
-      activesupport (= 7.0.8.5)
-    activerecord (7.0.8.5)
-      activemodel (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
-    activesupport (7.0.8.5)
+    activemodel (7.0.8.6)
+      activesupport (= 7.0.8.6)
+    activerecord (7.0.8.6)
+      activemodel (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
+    activesupport (7.0.8.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -57,7 +57,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    good_job (4.4.1)
+    good_job (4.4.2)
       activejob (>= 6.1.0)
       activerecord (>= 6.1.0)
       concurrent-ruby (>= 1.3.1)
@@ -66,19 +66,19 @@ GEM
       thor (>= 1.0.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    loofah (2.22.0)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
     minitest (5.25.1)
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
-    pg (1.5.8)
+    pg (1.5.9)
     puma (5.6.9)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -93,9 +93,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.0.8.5)
-      actionpack (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    railties (7.0.8.6)
+      actionpack (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -104,12 +104,13 @@ GEM
     thor (1.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.7.0)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 
@@ -128,4 +129,4 @@ DEPENDENCIES
   railties (~> 7.0.1)
 
 BUNDLED WITH
-   2.5.11
+   2.5.22

--- a/sample-apps/que-2-sample/Gemfile.lock
+++ b/sample-apps/que-2-sample/Gemfile.lock
@@ -1,44 +1,44 @@
 PATH
   remote: ../../judoscale-que
   specs:
-    judoscale-que (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-que (1.8.2)
+      judoscale-ruby (= 1.8.2)
       que (>= 1.0)
 
 PATH
   remote: ../../judoscale-rails
   specs:
-    judoscale-rails (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-rails (1.8.2)
+      judoscale-ruby (= 1.8.2)
       railties
 
 PATH
   remote: ../../judoscale-ruby
   specs:
-    judoscale-ruby (1.8.1)
+    judoscale-ruby (1.8.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.0.8.5)
-      actionview (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionpack (7.0.8.6)
+      actionview (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionview (7.0.8.6)
+      activesupport (= 7.0.8.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activemodel (7.0.8.5)
-      activesupport (= 7.0.8.5)
-    activerecord (7.0.8.5)
-      activemodel (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
-    activesupport (7.0.8.5)
+    activemodel (7.0.8.6)
+      activesupport (= 7.0.8.6)
+    activerecord (7.0.8.6)
+      activemodel (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
+    activesupport (7.0.8.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -49,22 +49,22 @@ GEM
     erubi (1.13.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    loofah (2.22.0)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
     minitest (5.25.1)
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
-    pg (1.5.8)
+    pg (1.5.9)
     puma (5.6.9)
       nio4r (~> 2.0)
-    que (2.4.0)
+    que (2.4.1)
     racc (1.8.1)
     rack (2.2.10)
     rack-test (2.1.0)
@@ -76,9 +76,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.0.8.5)
-      actionpack (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    railties (7.0.8.6)
+      actionpack (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -87,12 +87,13 @@ GEM
     thor (1.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.7.0)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 

--- a/sample-apps/rails-sample/Gemfile.lock
+++ b/sample-apps/rails-sample/Gemfile.lock
@@ -1,32 +1,32 @@
 PATH
   remote: ../../judoscale-rails
   specs:
-    judoscale-rails (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-rails (1.8.2)
+      judoscale-ruby (= 1.8.2)
       railties
 
 PATH
   remote: ../../judoscale-ruby
   specs:
-    judoscale-ruby (1.8.1)
+    judoscale-ruby (1.8.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.0.8.5)
-      actionview (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionpack (7.0.8.6)
+      actionview (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionview (7.0.8.6)
+      activesupport (= 7.0.8.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activesupport (7.0.8.5)
+    activesupport (7.0.8.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -37,12 +37,12 @@ GEM
     erubi (1.13.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    loofah (2.22.0)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
     minitest (5.25.1)
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
@@ -62,9 +62,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.0.8.5)
-      actionpack (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    railties (7.0.8.6)
+      actionpack (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -73,13 +73,14 @@ GEM
     thor (1.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.7.0)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 

--- a/sample-apps/resque-sample/Gemfile.lock
+++ b/sample-apps/resque-sample/Gemfile.lock
@@ -1,39 +1,39 @@
 PATH
   remote: ../../judoscale-rails
   specs:
-    judoscale-rails (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-rails (1.8.2)
+      judoscale-ruby (= 1.8.2)
       railties
 
 PATH
   remote: ../../judoscale-resque
   specs:
-    judoscale-resque (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-resque (1.8.2)
+      judoscale-ruby (= 1.8.2)
       resque (>= 2.0)
 
 PATH
   remote: ../../judoscale-ruby
   specs:
-    judoscale-ruby (1.8.1)
+    judoscale-ruby (1.8.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.0.8.5)
-      actionview (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionpack (7.0.8.6)
+      actionview (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionview (7.0.8.6)
+      activesupport (= 7.0.8.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activesupport (7.0.8.5)
+    activesupport (7.0.8.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -46,7 +46,7 @@ GEM
     erubi (1.13.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    loofah (2.22.0)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
@@ -55,7 +55,7 @@ GEM
     multi_json (1.15.0)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
@@ -78,9 +78,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.0.8.5)
-      actionpack (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    railties (7.0.8.6)
+      actionpack (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -107,13 +107,14 @@ GEM
     tilt (2.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.7.0)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 

--- a/sample-apps/shoryuken-sample/Gemfile.lock
+++ b/sample-apps/shoryuken-sample/Gemfile.lock
@@ -1,57 +1,57 @@
 PATH
   remote: ../../judoscale-rails
   specs:
-    judoscale-rails (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-rails (1.8.2)
+      judoscale-ruby (= 1.8.2)
       railties
 
 PATH
   remote: ../../judoscale-ruby
   specs:
-    judoscale-ruby (1.8.1)
+    judoscale-ruby (1.8.2)
 
 PATH
   remote: ../../judoscale-shoryuken
   specs:
-    judoscale-shoryuken (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-shoryuken (1.8.2)
+      judoscale-ruby (= 1.8.2)
       shoryuken (>= 6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.0.8.5)
-      actionview (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionpack (7.0.8.6)
+      actionview (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionview (7.0.8.6)
+      activesupport (= 7.0.8.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (7.0.8.5)
-      activesupport (= 7.0.8.5)
+    activejob (7.0.8.6)
+      activesupport (= 7.0.8.6)
       globalid (>= 0.3.6)
-    activesupport (7.0.8.5)
+    activesupport (7.0.8.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     aws-eventstream (1.3.0)
-    aws-partitions (1.991.0)
-    aws-sdk-core (3.209.1)
+    aws-partitions (1.1001.0)
+    aws-sdk-core (3.211.0)
       aws-eventstream (~> 1, >= 1.3.0)
-      aws-partitions (~> 1, >= 1.651.0)
+      aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-sqs (1.86.0)
-      aws-sdk-core (~> 3, >= 3.207.0)
+    aws-sdk-sqs (1.87.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
       aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.10.0)
+    aws-sigv4 (1.10.1)
       aws-eventstream (~> 1, >= 1.0.2)
     builder (3.3.0)
     concurrent-ruby (1.3.4)
@@ -66,12 +66,12 @@ GEM
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
-    loofah (2.22.0)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
     minitest (5.25.1)
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
@@ -91,9 +91,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.0.8.5)
-      actionpack (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    railties (7.0.8.6)
+      actionpack (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -106,13 +106,14 @@ GEM
     thor (1.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.7.0)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 

--- a/sample-apps/sidekiq-sample/Gemfile.lock
+++ b/sample-apps/sidekiq-sample/Gemfile.lock
@@ -1,39 +1,39 @@
 PATH
   remote: ../../judoscale-rails
   specs:
-    judoscale-rails (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-rails (1.8.2)
+      judoscale-ruby (= 1.8.2)
       railties
 
 PATH
   remote: ../../judoscale-ruby
   specs:
-    judoscale-ruby (1.8.1)
+    judoscale-ruby (1.8.2)
 
 PATH
   remote: ../../judoscale-sidekiq
   specs:
-    judoscale-sidekiq (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-sidekiq (1.8.2)
+      judoscale-ruby (= 1.8.2)
       sidekiq (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.0.8.5)
-      actionview (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionpack (7.0.8.6)
+      actionview (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.8.5)
-      activesupport (= 7.0.8.5)
+    actionview (7.0.8.6)
+      activesupport (= 7.0.8.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activesupport (7.0.8.5)
+    activesupport (7.0.8.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -45,12 +45,12 @@ GEM
     erubi (1.13.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    loofah (2.22.0)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
     minitest (5.25.1)
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
@@ -70,9 +70,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.0.8.5)
-      actionpack (= 7.0.8.5)
-      activesupport (= 7.0.8.5)
+    railties (7.0.8.6)
+      actionpack (= 7.0.8.6)
+      activesupport (= 7.0.8.6)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -86,13 +86,14 @@ GEM
     thor (1.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.7.0)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 

--- a/sample-apps/sinatra-sample/Gemfile.lock
+++ b/sample-apps/sinatra-sample/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../../judoscale-rack
   specs:
-    judoscale-rack (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-rack (1.8.2)
+      judoscale-ruby (= 1.8.2)
       rack
 
 PATH
   remote: ../../judoscale-ruby
   specs:
-    judoscale-ruby (1.8.1)
+    judoscale-ruby (1.8.2)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +16,7 @@ GEM
     base64 (0.2.0)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     puma (6.4.3)
       nio4r (~> 2.0)
     rack (3.1.8)
@@ -25,9 +25,8 @@ GEM
       rack (>= 3.0.0, < 4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
-    rackup (2.1.0)
+    rackup (2.2.0)
       rack (>= 3)
-      webrick (~> 1.8)
     ruby2_keywords (0.0.5)
     sinatra (4.0.0)
       mustermann (~> 3.0)
@@ -36,11 +35,11 @@ GEM
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
     tilt (2.4.0)
-    webrick (1.8.2)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-24
 
 DEPENDENCIES
   judoscale-rack!

--- a/sample-apps/solid_queue-sample/Gemfile.lock
+++ b/sample-apps/solid_queue-sample/Gemfile.lock
@@ -1,54 +1,54 @@
 PATH
   remote: ../../judoscale-rails
   specs:
-    judoscale-rails (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-rails (1.8.2)
+      judoscale-ruby (= 1.8.2)
       railties
 
 PATH
   remote: ../../judoscale-ruby
   specs:
-    judoscale-ruby (1.8.1)
+    judoscale-ruby (1.8.2)
 
 PATH
   remote: ../../judoscale-solid_queue
   specs:
-    judoscale-solid_queue (1.8.1)
-      judoscale-ruby (= 1.8.1)
+    judoscale-solid_queue (1.8.2)
+      judoscale-ruby (= 1.8.2)
       solid_queue (>= 0.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (7.1.4.1)
-      actionpack (= 7.1.4.1)
-      activesupport (= 7.1.4.1)
+    actioncable (7.1.5)
+      actionpack (= 7.1.5)
+      activesupport (= 7.1.5)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
-    actionmailbox (7.1.4.1)
-      actionpack (= 7.1.4.1)
-      activejob (= 7.1.4.1)
-      activerecord (= 7.1.4.1)
-      activestorage (= 7.1.4.1)
-      activesupport (= 7.1.4.1)
+    actionmailbox (7.1.5)
+      actionpack (= 7.1.5)
+      activejob (= 7.1.5)
+      activerecord (= 7.1.5)
+      activestorage (= 7.1.5)
+      activesupport (= 7.1.5)
       mail (>= 2.7.1)
       net-imap
       net-pop
       net-smtp
-    actionmailer (7.1.4.1)
-      actionpack (= 7.1.4.1)
-      actionview (= 7.1.4.1)
-      activejob (= 7.1.4.1)
-      activesupport (= 7.1.4.1)
+    actionmailer (7.1.5)
+      actionpack (= 7.1.5)
+      actionview (= 7.1.5)
+      activejob (= 7.1.5)
+      activesupport (= 7.1.5)
       mail (~> 2.5, >= 2.5.4)
       net-imap
       net-pop
       net-smtp
       rails-dom-testing (~> 2.2)
-    actionpack (7.1.4.1)
-      actionview (= 7.1.4.1)
-      activesupport (= 7.1.4.1)
+    actionpack (7.1.5)
+      actionview (= 7.1.5)
+      activesupport (= 7.1.5)
       nokogiri (>= 1.8.5)
       racc
       rack (>= 2.2.4)
@@ -56,51 +56,55 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    actiontext (7.1.4.1)
-      actionpack (= 7.1.4.1)
-      activerecord (= 7.1.4.1)
-      activestorage (= 7.1.4.1)
-      activesupport (= 7.1.4.1)
+    actiontext (7.1.5)
+      actionpack (= 7.1.5)
+      activerecord (= 7.1.5)
+      activestorage (= 7.1.5)
+      activesupport (= 7.1.5)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (7.1.4.1)
-      activesupport (= 7.1.4.1)
+    actionview (7.1.5)
+      activesupport (= 7.1.5)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activejob (7.1.4.1)
-      activesupport (= 7.1.4.1)
+    activejob (7.1.5)
+      activesupport (= 7.1.5)
       globalid (>= 0.3.6)
-    activemodel (7.1.4.1)
-      activesupport (= 7.1.4.1)
-    activerecord (7.1.4.1)
-      activemodel (= 7.1.4.1)
-      activesupport (= 7.1.4.1)
+    activemodel (7.1.5)
+      activesupport (= 7.1.5)
+    activerecord (7.1.5)
+      activemodel (= 7.1.5)
+      activesupport (= 7.1.5)
       timeout (>= 0.4.0)
-    activestorage (7.1.4.1)
-      actionpack (= 7.1.4.1)
-      activejob (= 7.1.4.1)
-      activerecord (= 7.1.4.1)
-      activesupport (= 7.1.4.1)
+    activestorage (7.1.5)
+      actionpack (= 7.1.5)
+      activejob (= 7.1.5)
+      activerecord (= 7.1.5)
+      activesupport (= 7.1.5)
       marcel (~> 1.0)
-    activesupport (7.1.4.1)
+    activesupport (7.1.5)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
       mutex_m
+      securerandom (>= 0.3)
       tzinfo (~> 2.0)
     base64 (0.2.0)
+    benchmark (0.3.0)
     bigdecimal (3.1.8)
     builder (3.3.0)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
-    date (3.3.4)
+    date (3.4.0)
     drb (2.2.1)
     erubi (1.13.0)
     et-orbi (1.2.11)
@@ -120,7 +124,8 @@ GEM
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    loofah (2.22.0)
+    logger (1.6.1)
+    loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -138,7 +143,7 @@ GEM
       stimulus-rails
       turbo-rails
     mutex_m (0.2.0)
-    net-imap (0.4.17)
+    net-imap (0.5.0)
       date
       net-protocol
     net-pop (0.1.2)
@@ -147,14 +152,14 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
-    pg (1.5.8)
+    pg (1.5.9)
     psych (5.1.2)
       stringio
     puma (6.4.3)
@@ -166,23 +171,22 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rackup (2.1.0)
+    rackup (2.2.0)
       rack (>= 3)
-      webrick (~> 1.8)
-    rails (7.1.4.1)
-      actioncable (= 7.1.4.1)
-      actionmailbox (= 7.1.4.1)
-      actionmailer (= 7.1.4.1)
-      actionpack (= 7.1.4.1)
-      actiontext (= 7.1.4.1)
-      actionview (= 7.1.4.1)
-      activejob (= 7.1.4.1)
-      activemodel (= 7.1.4.1)
-      activerecord (= 7.1.4.1)
-      activestorage (= 7.1.4.1)
-      activesupport (= 7.1.4.1)
+    rails (7.1.5)
+      actioncable (= 7.1.5)
+      actionmailbox (= 7.1.5)
+      actionmailer (= 7.1.5)
+      actionpack (= 7.1.5)
+      actiontext (= 7.1.5)
+      actionview (= 7.1.5)
+      activejob (= 7.1.5)
+      activemodel (= 7.1.5)
+      activerecord (= 7.1.5)
+      activestorage (= 7.1.5)
+      activesupport (= 7.1.5)
       bundler (>= 1.15.0)
-      railties (= 7.1.4.1)
+      railties (= 7.1.5)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -190,9 +194,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.1.4.1)
-      actionpack (= 7.1.4.1)
-      activesupport (= 7.1.4.1)
+    railties (7.1.5)
+      actionpack (= 7.1.5)
+      activesupport (= 7.1.5)
       irb
       rackup (>= 1.0.0)
       rake (>= 12.2)
@@ -203,6 +207,7 @@ GEM
       psych (>= 4.0.0)
     reline (0.5.10)
       io-console (~> 0.5)
+    securerandom (0.3.1)
     solid_queue (1.0.0)
       activejob (>= 7.1)
       activerecord (>= 7.1)
@@ -227,16 +232,16 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webrick (1.8.2)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.0)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 


### PR DESCRIPTION
We needed a place to document a gotcha recently discovered with `rescue-scheduler` that wasn't loading our latency extension, so I added another sub-section under "Worker adapters" for that.

This also takes the opportunity to document what each adapter collects specifically, so it's easier to visualize where queue latency vs queue depth is available, and which can support busy (if enabled).

See the Readme live: https://github.com/judoscale/judoscale-ruby/tree/ca-readme?tab=readme-ov-file#specific-worker-backend-notes

<details><summary>Sample</summary>
<p>

![Screenshot 2024-11-04 at 17 32 35](https://github.com/user-attachments/assets/98bf9baa-501c-487f-a07b-b50f58a8691d)

![Screenshot 2024-11-04 at 17 32 39](https://github.com/user-attachments/assets/7b691f7b-1c84-4af9-93d5-e37b007fd19d)

</p>
</details> 