### PR TITLE
chore: Update Solid Queue Ruby dependency

### DIFF
--- a/.github/workflows/judoscale-solid_queue-test.yml
+++ b/.github/workflows/judoscale-solid_queue-test.yml
@@ -21,8 +21,11 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
-        # exclude:
-        #   -
+        exclude:
+          - gemfile: Gemfile
+            ruby: "2.7"
+          - gemfile: Gemfile
+            ruby: "3.0"
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/judoscale-solid_queue/${{ matrix.gemfile }}

--- a/judoscale-solid_queue/judoscale-solid_queue.gemspec
+++ b/judoscale-solid_queue/judoscale-solid_queue.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.add_dependency "judoscale-ruby", Judoscale::VERSION
   spec.add_dependency "solid_queue", ">= 0.3"

--- a/judoscale-solid_queue/judoscale-solid_queue.gemspec
+++ b/judoscale-solid_queue/judoscale-solid_queue.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"].reject { |f| f.match?(%r{rails-autoscale}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "judoscale-ruby", Judoscale::VERSION
   spec.add_dependency "solid_queue", ">= 0.3"


### PR DESCRIPTION
Solid Queue internals use shorthand keyword argument syntax, which was introduced in Ruby 3.1.