### PR TITLE
Configure runtime container for Railway

### DIFF
--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -105,6 +105,8 @@ module Judoscale
         elsif ENV.include?("ECS_CONTAINER_METADATA_URI")
           instance = ENV["ECS_CONTAINER_METADATA_URI"].split("/").last
           RuntimeContainer.new instance
+        elsif ENV.include?("RAILWAY_REPLICA_ID")
+          RuntimeContainer.new ENV["RAILWAY_REPLICA_ID"]
         else
           # Unsupported platform...
           RuntimeContainer.new("")

--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -96,9 +96,8 @@ module Judoscale
       if ENV["RENDER_INSTANCE_ID"]
         instance = ENV["RENDER_INSTANCE_ID"].delete_prefix(ENV["RENDER_SERVICE_ID"]).delete_prefix("-")
         @current_runtime_container = RuntimeContainer.new instance
-        # Allow a custom API base URL to be set for Render (for testing)
-        @api_base_url ||= "https://adapter.judoscale.com/api"
-        @api_base_url += "/#{ENV["RENDER_SERVICE_ID"]}"
+        # Deprecated API url using the service ID for legacy render services not using `JUDOSCALE_URL`.
+        @api_base_url ||= "https://adapter.judoscale.com/api/#{ENV["RENDER_SERVICE_ID"]}"
       elsif ENV["DYNO"]
         @current_runtime_container = RuntimeContainer.new ENV["DYNO"]
       elsif (metadata_uri = ENV["ECS_CONTAINER_METADATA_URI"])

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -8,12 +8,12 @@ module Judoscale
     it "initializes the config from default heroku ENV vars and other sensible defaults" do
       env = {
         "DYNO" => "web.1",
-        "JUDOSCALE_URL" => "https://example.com"
+        "JUDOSCALE_URL" => "https://adapter.judoscale.com/api/1234567890"
       }
 
       use_env env do
         config = Config.instance
-        _(config.api_base_url).must_equal "https://example.com"
+        _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
         _(config.current_runtime_container).must_equal "web.1"
         _(config.log_level).must_be_nil
         _(config.logger).must_be_instance_of ::Logger
@@ -32,7 +32,7 @@ module Judoscale
       end
     end
 
-    it "initializes the config from default render ENV vars and other sensible defaults" do
+    it "initializes the config from default render ENV vars for render services" do
       env = {
         "RENDER_SERVICE_ID" => "srv-cfa1es5a49987h4vcvfg",
         "RENDER_INSTANCE_ID" => "srv-cfa1es5a49987h4vcvfg-5497f74465-m5wwr",
@@ -43,20 +43,22 @@ module Judoscale
         config = Config.instance
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/srv-cfa1es5a49987h4vcvfg"
         _(config.current_runtime_container).must_equal "5497f74465-m5wwr"
-        _(config.log_level).must_be_nil
-        _(config.logger).must_be_instance_of ::Logger
-        _(config.max_request_size_bytes).must_equal 100_000
-        _(config.report_interval_seconds).must_equal 10
+      end
 
-        enabled_adapter_configs = Config.adapter_configs.select(&:enabled).map(&:identifier)
-        _(enabled_adapter_configs).must_equal %i[test_job_config]
+    end
 
-        enabled_adapter_configs.each do |adapter_name|
-          adapter_config = config.public_send(adapter_name)
-          _(adapter_config.enabled).must_equal true
-          _(adapter_config.max_queues).must_equal 20
-          _(adapter_config.track_busy_jobs).must_equal false
-        end
+    it "initializes the config from default render ENV vars for legacy render services not using JUDOSCALE_URL" do
+      env = {
+        "JUDOSCALE_URL" => "https://adapter.judoscale.com/api/1234567890",
+        "RENDER_SERVICE_ID" => "srv-cfa1es5a49987h4vcvfg",
+        "RENDER_INSTANCE_ID" => "srv-cfa1es5a49987h4vcvfg-5497f74465-m5wwr",
+        "RENDER_SERVICE_TYPE" => "web"
+      }
+
+      use_env env do
+        config = Config.instance
+        _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890/srv-cfa1es5a49987h4vcvfg"
+        _(config.current_runtime_container).must_equal "5497f74465-m5wwr"
       end
     end
 

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -44,7 +44,6 @@ module Judoscale
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/srv-cfa1es5a49987h4vcvfg"
         _(config.current_runtime_container).must_equal "5497f74465-m5wwr"
       end
-
     end
 
     it "initializes the config from default render ENV vars for legacy render services not using JUDOSCALE_URL" do

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -76,6 +76,20 @@ module Judoscale
       end
     end
 
+    it "initializes the config from default Railway ENV vars" do
+      env = {
+        "RAILWAY_SERVICE_ID" => "1431de82-74ad-4f1a-b8f2-1952262d66cf",
+        "RAILWAY_REPLICA_ID" => "f9c88b6e-0e96-46f2-9884-ece3bf53d009",
+        "JUDOSCALE_URL" => "https://adapter.judoscale.com/api/1234567890"
+      }
+
+      use_env env do
+        config = Config.instance
+        _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
+        _(config.current_runtime_container).must_equal "f9c88b6e-0e96-46f2-9884-ece3bf53d009"
+      end
+    end
+
     it "allows ENV vars config overrides for the debug and URL" do
       env = {
         "DYNO" => "web.2",

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -57,7 +57,7 @@ module Judoscale
 
       use_env env do
         config = Config.instance
-        _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890/srv-cfa1es5a49987h4vcvfg"
+        _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
         _(config.current_runtime_container).must_equal "5497f74465-m5wwr"
       end
     end


### PR DESCRIPTION
We're early-testing Railway as a platform integration, this adds detection for the Railway environment to report the runtime container as the Railway Replica ID.

It also refactors a bit the runtime container logic, and stops appending the render service ID to the API url when it's set to JUDOSCALE_URL, as we don't need that anymore.

Related:

- https://github.com/judoscale/judoscale-python/pull/98
- https://github.com/judoscale/judoscale-node/pull/54