### PR TITLE
Explicitly require "logger" to fix good-job with Rails 6.1

### DIFF
--- a/judoscale-good_job/lib/judoscale/good_job.rb
+++ b/judoscale-good_job/lib/judoscale/good_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # require "good_job" fails unless we require these first
+require "logger"
 require "rails"
 require "active_support/core_ext/numeric/time"
 require "active_job/railtie"


### PR DESCRIPTION
Our Active Record / Rails 6.1. tests are failing with

    activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:16:
    in `<module:LoggerThreadSafeLevel>': uninitialized constant
    ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)

        Logger::Severity.constants.each do |severity|

Adding the explicit require is an attempt to fix those errors, and it shouldn't affect newer versions.

Failure sample: https://github.com/judoscale/judoscale-ruby/actions/runs/12830721399/job/35779717107