### PR TITLE
Configure runtime container for Fly.io

### DIFF
--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -105,6 +105,8 @@ module Judoscale
         elsif ENV.include?("ECS_CONTAINER_METADATA_URI")
           instance = ENV["ECS_CONTAINER_METADATA_URI"].split("/").last
           RuntimeContainer.new instance
+        elsif ENV.include?("FLY_MACHINE_ID")
+          RuntimeContainer.new ENV["FLY_MACHINE_ID"]
         elsif ENV.include?("RAILWAY_REPLICA_ID")
           RuntimeContainer.new ENV["RAILWAY_REPLICA_ID"]
         else

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -75,6 +75,20 @@ module Judoscale
       end
     end
 
+    it "initializes the config from default Fly ENV vars" do
+      env = {
+        "FLY_MACHINE_ID" => "683d924b322418",
+        "FLY_PROCESS_GROUP" => "web",
+        "JUDOSCALE_URL" => "https://adapter.judoscale.com/api/1234567890"
+      }
+
+      use_env env do
+        config = Config.instance
+        _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
+        _(config.current_runtime_container).must_equal "683d924b322418"
+      end
+    end
+
     it "initializes the config from default Railway ENV vars" do
       env = {
         "RAILWAY_SERVICE_ID" => "1431de82-74ad-4f1a-b8f2-1952262d66cf",


### PR DESCRIPTION
Adds detection for the Fly environment to report the runtime container as the Fly Machine ID.

(The Fly.io integration is currently in early-testing)

<details><summary>Sample ENV vars</summary>
<p>

![Screenshot 2025-02-17 at 11 25 42](https://github.com/user-attachments/assets/adb13219-49f8-410e-a02d-af6fb87df638)

</p>
</details> 
