### PR TITLE
Report the same time across all metrics collected on each adapter

### DIFF
--- a/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job/metrics_collector.rb
@@ -36,7 +36,7 @@ module Judoscale
 
       def collect
         metrics = []
-        t = Time.now.utc
+        time = Time.now.utc
 
         run_at_by_queue = select_rows_silently(METRICS_SQL).to_h
         self.queues |= run_at_by_queue.keys
@@ -50,14 +50,14 @@ module Judoscale
           run_at = run_at_by_queue[queue]
           # DateTime.parse assumes a UTC string
           run_at = DateTime.parse(run_at) if run_at.is_a?(String)
-          latency_ms = run_at ? ((t - run_at) * 1000).ceil : 0
+          latency_ms = run_at ? ((time - run_at) * 1000).ceil : 0
           latency_ms = 0 if latency_ms < 0
 
-          metrics.push Metric.new(:qt, latency_ms, t, queue)
+          metrics.push Metric.new(:qt, latency_ms, time, queue)
 
           if track_busy_jobs?
             busy_count = busy_count_by_queue[queue] || 0
-            metrics.push Metric.new(:busy, busy_count, Time.now, queue)
+            metrics.push Metric.new(:busy, busy_count, time, queue)
           end
         end
 

--- a/judoscale-good_job/lib/judoscale/good_job/metrics_collector.rb
+++ b/judoscale-good_job/lib/judoscale/good_job/metrics_collector.rb
@@ -68,7 +68,7 @@ module Judoscale
 
           if track_busy_jobs?
             busy_count = busy_count_by_queue[queue] || 0
-            metrics.push Metric.new(:busy, busy_count, Time.now, queue)
+            metrics.push Metric.new(:busy, busy_count, time, queue)
           end
         end
 

--- a/judoscale-que/lib/judoscale/que/metrics_collector.rb
+++ b/judoscale-que/lib/judoscale/que/metrics_collector.rb
@@ -44,7 +44,7 @@ module Judoscale
 
       def collect
         metrics = []
-        t = Time.now.utc
+        time = Time.now.utc
 
         run_at_by_queue = select_rows_silently(METRICS_SQL).to_h
         self.queues |= run_at_by_queue.keys
@@ -57,14 +57,14 @@ module Judoscale
         queues.each do |queue|
           run_at = run_at_by_queue[queue]
           run_at = DateTime.parse(run_at) if run_at.is_a?(String)
-          latency_ms = run_at ? ((t - run_at) * 1000).ceil : 0
+          latency_ms = run_at ? ((time - run_at) * 1000).ceil : 0
           latency_ms = 0 if latency_ms < 0
 
-          metrics.push Metric.new(:qt, latency_ms, t, queue)
+          metrics.push Metric.new(:qt, latency_ms, time, queue)
 
           if track_busy_jobs?
             busy_count = busy_count_by_queue[queue] || 0
-            metrics.push Metric.new(:busy, busy_count, Time.now, queue)
+            metrics.push Metric.new(:busy, busy_count, time, queue)
           end
         end
 

--- a/judoscale-resque/lib/judoscale/resque/metrics_collector.rb
+++ b/judoscale-resque/lib/judoscale/resque/metrics_collector.rb
@@ -12,6 +12,7 @@ module Judoscale
 
       def collect
         metrics = []
+        time = Time.now.utc
         current_queues = ::Resque.queues
 
         if track_busy_jobs?
@@ -31,12 +32,12 @@ module Judoscale
           depth = ::Resque.size(queue)
           latency = (::Resque.latency(queue) * 1000).ceil
 
-          metrics.push Metric.new(:qd, depth, Time.now, queue)
-          metrics.push Metric.new(:qt, latency, Time.now, queue)
+          metrics.push Metric.new(:qd, depth, time, queue)
+          metrics.push Metric.new(:qt, latency, time, queue)
 
           if track_busy_jobs?
             busy_count = busy_counts[queue]
-            metrics.push Metric.new(:busy, busy_count, Time.now, queue)
+            metrics.push Metric.new(:busy, busy_count, time, queue)
           end
         end
 

--- a/judoscale-shoryuken/lib/judoscale/shoryuken/metrics_collector.rb
+++ b/judoscale-shoryuken/lib/judoscale/shoryuken/metrics_collector.rb
@@ -14,6 +14,7 @@ module Judoscale
 
       def collect
         metrics = []
+        time = Time.now.utc
         self.queues |= ::Shoryuken.ungrouped_queues
 
         queues.each do |queue_name|
@@ -25,7 +26,7 @@ module Judoscale
             .get_queue_attributes(queue_url: queue.url, attribute_names: [SQS_QUEUE_DEPTH_ATTRIBUTE])
           depth = sqs_queue_attributes.attributes[SQS_QUEUE_DEPTH_ATTRIBUTE]
 
-          metrics.push Metric.new(:qd, depth, Time.now, queue_name)
+          metrics.push Metric.new(:qd, depth, time, queue_name)
         end
 
         log_collection(metrics)

--- a/judoscale-sidekiq/lib/judoscale/sidekiq/metrics_collector.rb
+++ b/judoscale-sidekiq/lib/judoscale/sidekiq/metrics_collector.rb
@@ -12,6 +12,7 @@ module Judoscale
 
       def collect
         metrics = []
+        time = Time.now.utc
         queues_by_name = ::Sidekiq::Queue.all.each_with_object({}) do |queue, obj|
           obj[queue.name] = queue
         end
@@ -35,12 +36,12 @@ module Judoscale
           latency_ms = (queue.latency * 1000).ceil
           depth = queue.size
 
-          metrics.push Metric.new(:qt, latency_ms, Time.now, queue_name)
-          metrics.push Metric.new(:qd, depth, Time.now, queue_name)
+          metrics.push Metric.new(:qt, latency_ms, time, queue_name)
+          metrics.push Metric.new(:qd, depth, time, queue_name)
 
           if track_busy_jobs?
             busy_count = busy_counts[queue_name]
-            metrics.push Metric.new(:busy, busy_count, Time.now, queue_name)
+            metrics.push Metric.new(:busy, busy_count, time, queue_name)
           end
         end
 

--- a/judoscale-solid_queue/lib/judoscale/solid_queue/metrics_collector.rb
+++ b/judoscale-solid_queue/lib/judoscale/solid_queue/metrics_collector.rb
@@ -51,7 +51,7 @@ module Judoscale
 
           if track_busy_jobs?
             busy_count = busy_count_by_queue[queue] || 0
-            metrics.push Metric.new(:busy, busy_count, Time.now, queue)
+            metrics.push Metric.new(:busy, busy_count, time, queue)
           end
         end
 


### PR DESCRIPTION
We had some metrics being reported with a shared "time" value that's initialized at the beginning of the collection methods, while other metrics had their own instance of time during the loop that fetches and pushes/queues the metrics.

This makes it a bit more consistent by always initializing the time at the beginning of the collection, and sharing that same time value for all created metrics within that collection loop for each adapter.