### PR TITLE
Track app time as a new metric

### DIFF
--- a/judoscale-rack/test/app_test.rb
+++ b/judoscale-rack/test/app_test.rb
@@ -22,8 +22,8 @@ module Judoscale
         _(last_response).must_be :ok?
         _(last_response.body).must_match(/Hello World/m)
 
-        _(MetricsStore.instance.metrics.size).must_equal i
-        _(MetricsStore.instance.metrics.last.identifier).must_equal :qt
+        _(MetricsStore.instance.metrics.size).must_equal i * 2
+        _(MetricsStore.instance.metrics.last(2).map(&:identifier)).must_equal [:qt, :at]
       }
     end
   end

--- a/judoscale-rails/test/app_test.rb
+++ b/judoscale-rails/test/app_test.rb
@@ -23,8 +23,8 @@ module Judoscale
         _(last_response).must_be :ok?
         _(last_response.body).must_equal "Hello World"
 
-        _(MetricsStore.instance.metrics.size).must_equal i
-        _(MetricsStore.instance.metrics.last.identifier).must_equal :qt
+        _(MetricsStore.instance.metrics.size).must_equal i * 2
+        _(MetricsStore.instance.metrics.last(2).map(&:identifier)).must_equal [:qt, :at]
       }
     end
   end

--- a/judoscale-ruby/lib/judoscale/request_metrics.rb
+++ b/judoscale-ruby/lib/judoscale/request_metrics.rb
@@ -16,7 +16,7 @@ module Judoscale
       @request_start_header = env["HTTP_X_REQUEST_START"]
     end
 
-    def track?
+    def track_queue_time?
       @request_start_header && !ignore_large_request?
     end
 

--- a/judoscale-ruby/lib/judoscale/request_metrics.rb
+++ b/judoscale-ruby/lib/judoscale/request_metrics.rb
@@ -31,6 +31,14 @@ module Judoscale
       (queue_time > 0) ? queue_time : 0
     end
 
+    def elapsed_time
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      response = yield
+      finish = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      [finish - start, response]
+    end
+
     private
 
     def ignore_large_request?

--- a/judoscale-ruby/lib/judoscale/request_middleware.rb
+++ b/judoscale-ruby/lib/judoscale/request_middleware.rb
@@ -33,9 +33,16 @@ module Judoscale
         end
 
         logger.debug "Request queue_time=#{queue_time}ms network_time=#{network_time}ms request_id=#{request_metrics.request_id} size=#{request_metrics.size}"
-      end
 
-      @app.call(env)
+        app_time, response = request_metrics.elapsed_time do
+          @app.call(env)
+        end
+        store.push :at, app_time, time
+
+        response
+      else
+        @app.call(env)
+      end
     end
   end
 end

--- a/judoscale-ruby/lib/judoscale/request_middleware.rb
+++ b/judoscale-ruby/lib/judoscale/request_middleware.rb
@@ -14,14 +14,13 @@ module Judoscale
     end
 
     def call(env)
-      Reporter.start
       request_metrics = RequestMetrics.new(env)
+      store = MetricsStore.instance
+      time = Time.now.utc
 
-      if request_metrics.track?
-        time = Time.now.utc
+      if request_metrics.track_queue_time?
         queue_time = request_metrics.queue_time(time)
         network_time = request_metrics.network_time
-        store = MetricsStore.instance
 
         # NOTE: Expose queue time to the app
         env["judoscale.queue_time"] = queue_time
@@ -33,16 +32,16 @@ module Judoscale
         end
 
         logger.debug "Request queue_time=#{queue_time}ms network_time=#{network_time}ms request_id=#{request_metrics.request_id} size=#{request_metrics.size}"
+      end
 
-        app_time, response = request_metrics.elapsed_time do
-          @app.call(env)
-        end
-        store.push :at, app_time, time
+      Reporter.start
 
-        response
-      else
+      app_time, response = request_metrics.elapsed_time do
         @app.call(env)
       end
+      store.push :at, app_time, time
+
+      response
     end
   end
 end

--- a/judoscale-ruby/test/middleware_test.rb
+++ b/judoscale-ruby/test/middleware_test.rb
@@ -93,7 +93,8 @@ module Judoscale
               middleware.call(env)
 
               metrics = MetricsStore.instance.flush
-              _(metrics.length).must_equal 0
+              _(metrics.length).must_equal 1
+              _(metrics[0].identifier).must_equal :at
             end
           end
 

--- a/judoscale-ruby/test/middleware_test.rb
+++ b/judoscale-ruby/test/middleware_test.rb
@@ -52,16 +52,19 @@ module Judoscale
           before { env["HTTP_X_REQUEST_START"] = five_seconds_ago_in_unix_millis.to_i.to_s }
           after { MetricsStore.instance.clear }
 
-          it "collects the request queue time" do
+          it "collects the request queue time and application time" do
             freeze_time now do
               middleware.call(env)
             end
 
             metrics = MetricsStore.instance.flush
-            _(metrics.length).must_equal 1
-            _(metrics.first).must_be_instance_of Metric
-            _(metrics.first.value).must_be_within_delta 5000, 1
-            _(metrics.first.identifier).must_equal :qt
+            _(metrics.length).must_equal 2
+            _(metrics[0]).must_be_instance_of Metric
+            _(metrics[0].value).must_be_within_delta 5000, 1
+            _(metrics[0].identifier).must_equal :qt
+            _(metrics[1]).must_be_instance_of Metric
+            _(metrics[1].value).must_be_within_delta 0, 0.1
+            _(metrics[1].identifier).must_equal :at
           end
 
           it "records the queue time in the environment passed on" do
@@ -101,10 +104,10 @@ module Judoscale
               middleware.call(env)
 
               metrics = MetricsStore.instance.flush
-              _(metrics.length).must_equal 2
-              _(metrics.last).must_be_instance_of Metric
-              _(metrics.last.value).must_equal 50
-              _(metrics.last.identifier).must_equal :nt
+              _(metrics.length).must_equal 3
+              _(metrics[1]).must_be_instance_of Metric
+              _(metrics[1].value).must_equal 50
+              _(metrics[1].identifier).must_equal :nt
             end
 
             it "records the network time in the environment passed on" do

--- a/judoscale-ruby/test/request_metrics_test.rb
+++ b/judoscale-ruby/test/request_metrics_test.rb
@@ -62,5 +62,17 @@ module Judoscale
         end
       end
     end
+
+    describe "#elapsed_time" do
+      it "calculates the time taken to run the given block, returning both the time and the result of the block" do
+        time, response = request.elapsed_time do
+          sleep 0.0001
+          "something that takes time"
+        end
+
+        _(time).must_be_within_delta 0.0001, 0.001
+        _(response).must_equal "something that takes time"
+      end
+    end
   end
 end


### PR DESCRIPTION
This can be useful to help determine internally if queue time increase
has direct relation to app time increase, or actual capacity issues, so
we'll track it as a new metric.