### PR TITLE
Request middleware improvements

### DIFF
--- a/judoscale-ruby/lib/judoscale/request_metrics.rb
+++ b/judoscale-ruby/lib/judoscale/request_metrics.rb
@@ -21,10 +21,7 @@ module Judoscale
     end
 
     def queue_time(now = Time.now)
-      return if started_at.nil?
-      now = now.utc
-
-      queue_time = ((now - started_at) * 1000).to_i
+      queue_time = ((now.utc - started_at.utc) * 1000).to_i
 
       # Subtract the time Puma spent waiting on the request body, i.e. the network time. It's irrelevant to
       # capacity-related queue time. Without this, slow clients and large request payloads will skew queue time.
@@ -41,27 +38,24 @@ module Judoscale
     end
 
     def started_at
-      @started_at ||= if @request_start_header
-        # There are several variants of this header. We handle these:
-        #   - whole milliseconds (Heroku)
-        #   - whole microseconds (???)
-        #   - whole nanoseconds (Render)
-        #   - fractional seconds (NGINX)
-        #   - preceeding "t=" (NGINX)
-        value = @request_start_header.gsub(/[^0-9.]/, "").to_f
+      # There are several variants of this header. We handle these:
+      #   - whole milliseconds (Heroku)
+      #   - whole microseconds (???)
+      #   - whole nanoseconds (Render)
+      #   - fractional seconds (NGINX)
+      #   - preceeding "t=" (NGINX)
+      value = @request_start_header.gsub(/[^0-9.]/, "").to_f
 
-        # `value` could be seconds, milliseconds, microseconds or nanoseconds.
-        # We use some arbitrary cutoffs to determine which one it is.
-
-        if value > NANOSECONDS_CUTOFF
-          Time.at(value / 1_000_000_000.0)
-        elsif value > MICROSECONDS_CUTOFF
-          Time.at(value / 1_000_000.0)
-        elsif value > MILLISECONDS_CUTOFF
-          Time.at(value / 1000.0)
-        else
-          Time.at(value)
-        end.utc
+      # `value` could be seconds, milliseconds, microseconds or nanoseconds.
+      # We use some arbitrary cutoffs to determine which one it is.
+      if value > NANOSECONDS_CUTOFF
+        Time.at(value / 1_000_000_000.0)
+      elsif value > MICROSECONDS_CUTOFF
+        Time.at(value / 1_000_000.0)
+      elsif value > MILLISECONDS_CUTOFF
+        Time.at(value / 1000.0)
+      else
+        Time.at(value)
       end
     end
   end

--- a/judoscale-ruby/lib/judoscale/request_metrics.rb
+++ b/judoscale-ruby/lib/judoscale/request_metrics.rb
@@ -20,8 +20,27 @@ module Judoscale
       @request_start_header && !ignore_large_request?
     end
 
+    def queue_time(now = Time.now)
+      return if started_at.nil?
+
+      queue_time = ((now - started_at) * 1000).to_i
+
+      # Subtract the time Puma spent waiting on the request body, i.e. the network time. It's irrelevant to
+      # capacity-related queue time. Without this, slow clients and large request payloads will skew queue time.
+      queue_time -= network_time
+
+      # Safeguard against negative queue times (should not happen in practice)
+      (queue_time > 0) ? queue_time : 0
+    end
+
+    private
+
+    def ignore_large_request?
+      @config.ignore_large_requests? && @size > @config.max_request_size_bytes
+    end
+
     def started_at
-      if @request_start_header
+      @started_at ||= if @request_start_header
         # There are several variants of this header. We handle these:
         #   - whole milliseconds (Heroku)
         #   - whole microseconds (???)
@@ -43,25 +62,6 @@ module Judoscale
           Time.at(value)
         end
       end
-    end
-
-    def queue_time(now = Time.now)
-      return if started_at.nil?
-
-      queue_time = ((now - started_at) * 1000).to_i
-
-      # Subtract the time Puma spent waiting on the request body, i.e. the network time. It's irrelevant to
-      # capacity-related queue time. Without this, slow clients and large request payloads will skew queue time.
-      queue_time -= network_time
-
-      # Safeguard against negative queue times (should not happen in practice)
-      (queue_time > 0) ? queue_time : 0
-    end
-
-    private
-
-    def ignore_large_request?
-      @config.ignore_large_requests? && @size > @config.max_request_size_bytes
     end
   end
 end

--- a/judoscale-ruby/lib/judoscale/request_metrics.rb
+++ b/judoscale-ruby/lib/judoscale/request_metrics.rb
@@ -16,8 +16,8 @@ module Judoscale
       @request_start_header = env["HTTP_X_REQUEST_START"]
     end
 
-    def ignore?
-      @config.ignore_large_requests? && @size > @config.max_request_size_bytes
+    def track?
+      @request_start_header && !ignore_large_request?
     end
 
     def started_at
@@ -56,6 +56,12 @@ module Judoscale
 
       # Safeguard against negative queue times (should not happen in practice)
       (queue_time > 0) ? queue_time : 0
+    end
+
+    private
+
+    def ignore_large_request?
+      @config.ignore_large_requests? && @size > @config.max_request_size_bytes
     end
   end
 end

--- a/judoscale-ruby/lib/judoscale/request_metrics.rb
+++ b/judoscale-ruby/lib/judoscale/request_metrics.rb
@@ -22,6 +22,7 @@ module Judoscale
 
     def queue_time(now = Time.now)
       return if started_at.nil?
+      now = now.utc
 
       queue_time = ((now - started_at) * 1000).to_i
 
@@ -60,7 +61,7 @@ module Judoscale
           Time.at(value / 1000.0)
         else
           Time.at(value)
-        end
+        end.utc
       end
     end
   end

--- a/judoscale-ruby/lib/judoscale/request_middleware.rb
+++ b/judoscale-ruby/lib/judoscale/request_middleware.rb
@@ -17,12 +17,9 @@ module Judoscale
       Reporter.start
       request_metrics = RequestMetrics.new(env)
 
-      unless request_metrics.ignore?
+      if request_metrics.track?
         queue_time = request_metrics.queue_time
         network_time = request_metrics.network_time
-      end
-
-      if queue_time
         store = MetricsStore.instance
 
         # NOTE: Expose queue time to the app

--- a/judoscale-ruby/lib/judoscale/request_middleware.rb
+++ b/judoscale-ruby/lib/judoscale/request_middleware.rb
@@ -18,17 +18,18 @@ module Judoscale
       request_metrics = RequestMetrics.new(env)
 
       if request_metrics.track?
-        queue_time = request_metrics.queue_time
+        time = Time.now.utc
+        queue_time = request_metrics.queue_time(time)
         network_time = request_metrics.network_time
         store = MetricsStore.instance
 
         # NOTE: Expose queue time to the app
         env["judoscale.queue_time"] = queue_time
-        store.push :qt, queue_time
+        store.push :qt, queue_time, time
 
         unless network_time.zero?
           env["judoscale.network_time"] = network_time
-          store.push :nt, network_time
+          store.push :nt, network_time, time
         end
 
         logger.debug "Request queue_time=#{queue_time}ms network_time=#{network_time}ms request_id=#{request_metrics.request_id} size=#{request_metrics.size}"

--- a/judoscale-ruby/lib/judoscale/request_middleware.rb
+++ b/judoscale-ruby/lib/judoscale/request_middleware.rb
@@ -14,14 +14,13 @@ module Judoscale
     end
 
     def call(env)
+      Reporter.start
       request_metrics = RequestMetrics.new(env)
 
       unless request_metrics.ignore?
         queue_time = request_metrics.queue_time
         network_time = request_metrics.network_time
       end
-
-      Reporter.start
 
       if queue_time
         store = MetricsStore.instance


### PR DESCRIPTION
Simplify conditionals, avoid building request started timestamp twice per-request, use UTC for time math, use a shared timestamp for tracking all metrics during the request.