### PR TITLE
Track app time as milliseconds to match queue time

### DIFF
--- a/judoscale-ruby/lib/judoscale/request_metrics.rb
+++ b/judoscale-ruby/lib/judoscale/request_metrics.rb
@@ -36,7 +36,8 @@ module Judoscale
       response = yield
       finish = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-      [finish - start, response]
+      elapsed = ((finish - start) * 1000).to_i
+      [elapsed, response]
     end
 
     private

--- a/judoscale-ruby/test/request_metrics_test.rb
+++ b/judoscale-ruby/test/request_metrics_test.rb
@@ -64,13 +64,13 @@ module Judoscale
     end
 
     describe "#elapsed_time" do
-      it "calculates the time taken to run the given block, returning both the time and the result of the block" do
+      it "calculates the time taken to run the given block, returning both the time as milliseconds and the result of the block" do
         time, response = request.elapsed_time do
-          sleep 0.0001
+          sleep 0.001
           "something that takes time"
         end
 
-        _(time).must_be_within_delta 0.0001, 0.01
+        _(time).must_be_within_delta 1, 0.01
         _(response).must_equal "something that takes time"
       end
     end


### PR DESCRIPTION
The app time metric we introduced in #238 is tracking the raw elapsed time without any conversion, but we should track it as milliseconds and round it to an integer value like we're doing with queue time, to keep them consistent.