### PR TITLE
Update Gemfile.lock files during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      pr_created: ${{ steps.release.outputs.prs_created }}
     steps:
       - name: Release
         id: release
@@ -20,6 +21,26 @@ jobs:
           package-name: release-please-action
           bump-minor-pre-major: true
           version-file: "judoscale-ruby/lib/judoscale/version.rb"
+
+  update-gemfile-versions:
+    name: Update version in Gemfile.lock files
+    needs: release-please
+    runs-on: ubuntu-latest
+    if: ${{ needs.release-please.outputs.pr_created == 'true' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+
+      - name: Update versions
+        run:
+          bin/foreach bundle install
+          git commit -a -m 'Update Gemfile.lock versions'
 
   publish:
     name: Publish to Rubygems
@@ -34,7 +55,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
 
       - name: Publish gems
         env:


### PR DESCRIPTION
This is meant to update the Gemfile.lock files to the new version that's
being created, otherwise they'll become invalid when we merge the
release PR, causing test failures and requiring us to manually run bundle
install, as it happened with v1.11.0.

I tried a few combinations using release-please "updater" concept via
the `GemfileLock` that comes with Ruby, but it only seems to apply if
having a single `Gemfile.lock` file in the main repo, or if we used
their multirepo setup. Since none of those worked I went with a manual
attempt by setting up Ruby/bundle and running install & commit.
