### PR TITLE
Sleep before running the first metrics collection

### DIFF
--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -50,11 +50,11 @@ module Judoscale
         Thread.current.thread_variable_set(:fork_safe, true)
 
         loop do
-          run_metrics_collection(config, metrics_collectors)
-
           # Stagger reporting to spread out reports from many processes
           multiplier = 1 - (rand / 4) # between 0.75 and 1.0
           sleep config.report_interval_seconds * multiplier
+
+          run_metrics_collection(config, metrics_collectors)
         end
       end
     end


### PR DESCRIPTION
The current ordering has led to some unexpected results, particularly with [utilization tracking in the first report](https://github.com/judoscale/judoscale-ruby/pull/248#discussion_r2254633717). Our Python package already sleeps first (https://github.com/judoscale/judoscale-python/pull/78), so this brings our Ruby gem in line with that approach.