### PR TITLE
Configure timeouts of 5s for api requests

### DIFF
--- a/judoscale-ruby/lib/judoscale/adapter_api.rb
+++ b/judoscale-ruby/lib/judoscale/adapter_api.rb
@@ -38,7 +38,7 @@ module Judoscale
       uri = URI.parse("#{@config.api_base_url}#{options.fetch(:path)}")
       ssl = uri.scheme == "https"
 
-      response = Net::HTTP.start(uri.host, uri.port, use_ssl: ssl) do |http|
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: ssl, open_timeout: 5, read_timeout: 5, write_timeout: 5) do |http|
         request = Net::HTTP::Post.new(uri.request_uri, options[:headers] || {})
         request.body = options.fetch(:body)
 


### PR DESCRIPTION
This is already set by the python library, and will be our default.

Node.: https://github.com/judoscale/judoscale-node/pull/84
Python: https://github.com/judoscale/judoscale-python/blob/c1e0aa08fc68569b69a48f83d7b48e4be3ae6744/judoscale/core/reporter.py#L123

Closes https://github.com/judoscale/judoscale-ruby/issues/251