### PR TITLE
Handle loggers with level returning an identifier instead of integer

### DIFF
--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -139,14 +139,23 @@ module Judoscale
     def get_severity_log_level(log_level)
       return nil if log_level.to_s.strip.empty?
 
-      upcased_log_level = log_level.to_s.upcase
+      self.class.coerce_log_level(log_level)
+    rescue ArgumentError
+      logger.warn "Invalid log_level detected: #{log_level}"
+      nil
+    end
 
-      if ::Logger::Severity.const_defined?(upcased_log_level)
-        ::Logger::Severity.const_get(upcased_log_level)
+    def self.coerce_log_level(level)
+      if level.is_a?(Integer)
+        level
       else
-        logger.warn "Invalid log_level detected: #{log_level}"
+        upcased_level = level.to_s.upcase
 
-        nil
+        if ::Logger::Severity.const_defined?(upcased_level)
+          ::Logger::Severity.const_get(upcased_level)
+        else
+          raise ArgumentError, "invalid log level: #{level}"
+        end
       end
     end
   end

--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -74,6 +74,20 @@ module Judoscale
       end
     end
 
+    def self.coerce_log_level(level)
+      if level.is_a?(Integer)
+        level
+      else
+        upcased_level = level.to_s.upcase
+
+        if ::Logger::Severity.const_defined?(upcased_level)
+          ::Logger::Severity.const_get(upcased_level)
+        else
+          raise ArgumentError, "invalid log level: #{level}"
+        end
+      end
+    end
+
     attr_accessor :api_base_url, :report_interval_seconds,
       :max_request_size_bytes, :logger, :log_tag, :current_runtime_container
     attr_reader :log_level
@@ -143,20 +157,6 @@ module Judoscale
     rescue ArgumentError
       logger.warn "Invalid log_level detected: #{log_level}"
       nil
-    end
-
-    def self.coerce_log_level(level)
-      if level.is_a?(Integer)
-        level
-      else
-        upcased_level = level.to_s.upcase
-
-        if ::Logger::Severity.const_defined?(upcased_level)
-          ::Logger::Severity.const_get(upcased_level)
-        else
-          raise ArgumentError, "invalid log level: #{level}"
-        end
-      end
     end
   end
 end

--- a/judoscale-ruby/lib/judoscale/logger.rb
+++ b/judoscale-ruby/lib/judoscale/logger.rb
@@ -26,14 +26,12 @@ module Judoscale
         if log_level.nil?
           logger.public_send(severity_name.downcase) { tag(messages) }
         elsif severity_level >= log_level
-          logger_level = Logger.coerce_level(logger.level)
-          if severity_level >= logger_level
+          if severity_level >= Logger.coerce_level(logger.level)
             logger.public_send(severity_name.downcase) { tag(messages) }
           else
             # Our logger proxy is configured with a lower severity level than the underlying logger,
             # so send this message using the underlying logger severity instead of the actual severity.
-            logger_severity_name = ::Logger::SEV_LABEL[logger_level].downcase
-            logger.public_send(logger_severity_name) { tag(messages, tag_level: severity_name) }
+            logger.add(logger.level) { tag(messages, tag_level: severity_name) }
           end
         end
       end

--- a/judoscale-ruby/lib/judoscale/logger.rb
+++ b/judoscale-ruby/lib/judoscale/logger.rb
@@ -5,18 +5,6 @@ require "logger"
 
 module Judoscale
   module Logger
-    def self.coerce_level(level)
-      return level if level.is_a?(Integer)
-
-      upcased_level = level.to_s.upcase
-
-      if ::Logger::Severity.const_defined?(upcased_level)
-        ::Logger::Severity.const_get(upcased_level)
-      else
-        raise ArgumentError, "invalid log level: #{level}"
-      end
-    end
-
     def logger
       if @logger && @logger.log_level == Config.instance.log_level
         @logger
@@ -34,7 +22,7 @@ module Judoscale
         if log_level.nil?
           logger.public_send(severity_name.downcase) { tag(messages) }
         elsif severity_level >= log_level
-          if severity_level >= Logger.coerce_level(logger.level)
+          if severity_level >= Config.coerce_log_level(logger.level)
             logger.public_send(severity_name.downcase) { tag(messages) }
           else
             # Our logger proxy is configured with a lower severity level than the underlying logger,

--- a/judoscale-ruby/lib/judoscale/logger.rb
+++ b/judoscale-ruby/lib/judoscale/logger.rb
@@ -6,7 +6,15 @@ require "logger"
 module Judoscale
   module Logger
     def self.coerce_level(level)
-      ::Logger::Severity.coerce(level)
+      return level if level.is_a?(Integer)
+
+      upcased_level = level.to_s.upcase
+
+      if ::Logger::Severity.const_defined?(upcased_level)
+        ::Logger::Severity.const_get(upcased_level)
+      else
+        raise ArgumentError, "invalid log level: #{level}"
+      end
     end
 
     def logger

--- a/judoscale-ruby/lib/judoscale/logger.rb
+++ b/judoscale-ruby/lib/judoscale/logger.rb
@@ -5,6 +5,10 @@ require "logger"
 
 module Judoscale
   module Logger
+    def self.coerce_level(level)
+      ::Logger::Severity.coerce(level)
+    end
+
     def logger
       if @logger && @logger.log_level == Config.instance.log_level
         @logger
@@ -22,12 +26,13 @@ module Judoscale
         if log_level.nil?
           logger.public_send(severity_name.downcase) { tag(messages) }
         elsif severity_level >= log_level
-          if severity_level >= logger.level
+          logger_level = Logger.coerce_level(logger.level)
+          if severity_level >= logger_level
             logger.public_send(severity_name.downcase) { tag(messages) }
           else
             # Our logger proxy is configured with a lower severity level than the underlying logger,
             # so send this message using the underlying logger severity instead of the actual severity.
-            logger_severity_name = ::Logger::SEV_LABEL[logger.level].downcase
+            logger_severity_name = ::Logger::SEV_LABEL[logger_level].downcase
             logger.public_send(logger_severity_name) { tag(messages, tag_level: severity_name) }
           end
         end

--- a/judoscale-ruby/test/logger_test.rb
+++ b/judoscale-ruby/test/logger_test.rb
@@ -74,26 +74,25 @@ module Judoscale
       end
     end
 
-    class LoggerSymbol < ::Logger
-      def level
-        ::Logger::SEV_LABEL[super].downcase.to_sym
-      end
-
-      def level=(new_level)
-        super Judoscale::Config.coerce_log_level(new_level)
-      end
-
-      def add(severity, message = nil, *)
-        # Bypass the severity/level check inside Logger that'd fail with Integer vs symbol too.
-        # Log everything.
-        @logdev.write("LEVEL=#{level} SEVERITY=#{severity} #{message || yield}")
-        true
-      end
-      alias_method :log, :add
-    end
-
     it "gracefully handles logger level using symbols/strings (such as rails-semantic-logger)" do
-      original_logger = LoggerSymbol.new(string_io)
+      logger_symbol_class = Class.new(::Logger) do
+        def level
+          ::Logger::SEV_LABEL[super].downcase.to_sym
+        end
+
+        def level=(new_level)
+          super(Judoscale::Config.coerce_log_level(new_level))
+        end
+
+        def add(severity, message = nil, *)
+          # Bypass the severity/level check inside Logger that'd fail with Integer vs symbol too.
+          # Log everything.
+          @logdev.write("LEVEL=#{level} SEVERITY=#{severity} #{message || yield}")
+          true
+        end
+        alias_method :log, :add
+      end
+      original_logger = logger_symbol_class.new(string_io)
       original_logger.level = :info
 
       use_config logger: original_logger, log_level: :warn do
@@ -103,7 +102,7 @@ module Judoscale
         logger.warn "some warning"
         _(messages).must_include "LEVEL=info SEVERITY=2 [Judoscale] some warning"
 
-        original_logger.level = :ERROR
+        original_logger.level = :error
         logger.warn "other warning"
 
         _(messages).must_include "LEVEL=error SEVERITY=error [Judoscale] [WARN] other warning"

--- a/judoscale-ruby/test/logger_test.rb
+++ b/judoscale-ruby/test/logger_test.rb
@@ -73,5 +73,40 @@ module Judoscale
         end
       end
     end
+
+    class LoggerSymbol < ::Logger
+      def level
+        ::Logger::SEV_LABEL[super].downcase.to_sym
+      end
+
+      def level=(new_level)
+        super ::Logger::Severity.coerce(new_level)
+      end
+
+      def add(severity, message = nil, *)
+        # Bypass the severity/level check inside Logger that'd fail with Integer vs symbol too.
+        # Log everything.
+        @logdev.write("LEVEL=#{level} SEVERITY=#{severity} #{message || yield}")
+        true
+      end
+    end
+
+    it "gracefully handles logger level using symbols/strings (such as rails-semantic-logger)" do
+      original_logger = LoggerSymbol.new(string_io)
+      original_logger.level = :info
+
+      use_config logger: original_logger, log_level: :warn do
+        logger.info "some info"
+        _(messages).wont_include "some info"
+
+        logger.warn "some warning"
+        _(messages).must_include "LEVEL=info SEVERITY=2 [Judoscale] some warning"
+
+        original_logger.level = :ERROR
+        logger.warn "other warning"
+
+        _(messages).must_include "LEVEL=error SEVERITY=3 [Judoscale] [WARN] other warning"
+      end
+    end
   end
 end

--- a/judoscale-ruby/test/logger_test.rb
+++ b/judoscale-ruby/test/logger_test.rb
@@ -80,7 +80,7 @@ module Judoscale
       end
 
       def level=(new_level)
-        super Judoscale::Logger.coerce_level(new_level)
+        super Judoscale::Config.coerce_log_level(new_level)
       end
 
       def add(severity, message = nil, *)

--- a/judoscale-ruby/test/logger_test.rb
+++ b/judoscale-ruby/test/logger_test.rb
@@ -80,7 +80,7 @@ module Judoscale
       end
 
       def level=(new_level)
-        super ::Logger::Severity.coerce(new_level)
+        super Judoscale::Logger.coerce_level(new_level)
       end
 
       def add(severity, message = nil, *)
@@ -89,6 +89,7 @@ module Judoscale
         @logdev.write("LEVEL=#{level} SEVERITY=#{severity} #{message || yield}")
         true
       end
+      alias_method :log, :add
     end
 
     it "gracefully handles logger level using symbols/strings (such as rails-semantic-logger)" do
@@ -105,7 +106,7 @@ module Judoscale
         original_logger.level = :ERROR
         logger.warn "other warning"
 
-        _(messages).must_include "LEVEL=error SEVERITY=3 [Judoscale] [WARN] other warning"
+        _(messages).must_include "LEVEL=error SEVERITY=error [Judoscale] [WARN] other warning"
       end
     end
   end


### PR DESCRIPTION
Ruby's Logger uses Integer values to represent each "level" / severity,
and most other logging libraries follow that API.

    > ::Logger::DEBUG
    => 0
    > ::Logger::INFO
    => 1

https://github.com/ruby/logger/blob/e6bf1da59e8c3453c480d6bab9492eb797ccf455/lib/logger/severity.rb#L6-L17

However, Semantic Logger (and maybe some other libraries we don't know
about) uses levels with identifiers such as `:debug` directly

    > SemanticLogger::Levels::LEVELS
    => [:trace, :debug, :info, :warn, :error, :fatal]

https://github.com/reidmorrison/semantic_logger/blob/bae745b222e99170487575d491e4592c08cc856f/lib/semantic_logger/base.rb#L12-L35
https://github.com/reidmorrison/semantic_logger/blob/bae745b222e99170487575d491e4592c08cc856f/lib/semantic_logger/levels.rb#L4

which we need to map to logger "integer" levels, othewise we get errors
trying to compare them:

    lib/judoscale/logger.rb:25:in 'Integer#>=':
    comparison of Integer with :debug failed (ArgumentError)

              if severity_level >= logger.level

In order to handle these, we will try to coerce the underlying logger
level to integer so we can compare both the log severity level (from
Ruby's ::Logger) to the underlying logger level correctly.

This exception would happen inside our Reporter thread, which could kill
the thread and stop reporting metrics altogether.