### PR TITLE
Add support to JUDOSCALE_CONTAINER ENV var for custom containers

### DIFF
--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -108,7 +108,9 @@ module Judoscale
       self.class.adapter_configs.each(&:reset)
 
       @current_runtime_container =
-        if ENV.include?("DYNO")
+        if ENV.include?("JUDOSCALE_CONTAINER")
+          RuntimeContainer.new ENV["JUDOSCALE_CONTAINER"]
+        elsif ENV.include?("DYNO")
           RuntimeContainer.new ENV["DYNO"]
         elsif ENV.include?("RENDER_INSTANCE_ID")
           # Deprecated API url using the service ID for legacy render services not using `JUDOSCALE_URL`.

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -103,6 +103,32 @@ module Judoscale
       end
     end
 
+    it "initializes the config from JUDOSCALE_CONTAINER ENV var" do
+      env = {
+        "JUDOSCALE_CONTAINER" => "custom-container-123",
+        "JUDOSCALE_URL" => "https://adapter.judoscale.com/api/1234567890"
+      }
+
+      use_env env do
+        config = Config.instance
+        _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
+        _(config.current_runtime_container).must_equal "custom-container-123"
+      end
+    end
+
+    it "prioritizes JUDOSCALE_CONTAINER over platform-specific ENV vars" do
+      env = {
+        "JUDOSCALE_CONTAINER" => "custom-container-123",
+        "DYNO" => "web.1",
+        "JUDOSCALE_URL" => "https://adapter.judoscale.com/api/1234567890"
+      }
+
+      use_env env do
+        config = Config.instance
+        _(config.current_runtime_container).must_equal "custom-container-123"
+      end
+    end
+
     it "allows ENV vars config overrides for the debug and URL" do
       env = {
         "DYNO" => "web.2",


### PR DESCRIPTION
With this, it will be possible to provide a `JUDOSCALE_CONTAINER` env var to setup the runtime container when using custom setups, or to override the default logic for a platform in case it's necessary.

- Ruby: https://github.com/judoscale/judoscale-ruby/pull/261
- Python: https://github.com/judoscale/judoscale-python/pull/122
- Node: https://github.com/judoscale/judoscale-node/pull/88
- Java: https://github.com/judoscale/judoscale-java/pull/7