### PR TITLE
Switch to runtime_version across the board for consistency

### DIFF
--- a/judoscale-delayed_job/lib/judoscale/delayed_job.rb
+++ b/judoscale-delayed_job/lib/judoscale/delayed_job.rb
@@ -9,7 +9,7 @@ require "delayed_job_active_record"
 Judoscale.add_adapter :"judoscale-delayed_job",
   {
     adapter_version: Judoscale::VERSION,
-    framework_version: Gem.loaded_specs["delayed_job_active_record"].version.to_s # DJ doesn't have a `VERSION` constant
+    runtime_version: Gem.loaded_specs["delayed_job_active_record"].version.to_s # DJ doesn't have a `VERSION` constant
   },
   metrics_collector: Judoscale::DelayedJob::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:delayed_job)

--- a/judoscale-good_job/lib/judoscale/good_job.rb
+++ b/judoscale-good_job/lib/judoscale/good_job.rb
@@ -14,7 +14,7 @@ require "judoscale/good_job/metrics_collector"
 Judoscale.add_adapter :"judoscale-good_job",
   {
     adapter_version: Judoscale::VERSION,
-    framework_version: ::GoodJob::VERSION
+    runtime_version: ::GoodJob::VERSION
   },
   metrics_collector: Judoscale::GoodJob::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:good_job)

--- a/judoscale-que/lib/judoscale/que.rb
+++ b/judoscale-que/lib/judoscale/que.rb
@@ -9,7 +9,7 @@ require "que"
 Judoscale.add_adapter :"judoscale-que",
   {
     adapter_version: Judoscale::VERSION,
-    framework_version: ::Que::VERSION
+    runtime_version: ::Que::VERSION
   },
   metrics_collector: Judoscale::Que::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:que)

--- a/judoscale-rack/lib/judoscale/rack.rb
+++ b/judoscale-rack/lib/judoscale/rack.rb
@@ -12,5 +12,5 @@ require "rack"
 Judoscale.add_adapter :"judoscale-rack", {
   adapter_version: Judoscale::VERSION,
   # Rack deprecated `version` in v3, removed in v3.1.
-  framework_version: ::Rack.respond_to?(:release) ? ::Rack.release : ::Rack.version
+  runtime_version: ::Rack.respond_to?(:release) ? ::Rack.release : ::Rack.version
 }, metrics_collector: Judoscale::WebMetricsCollector

--- a/judoscale-rails/lib/judoscale/rails.rb
+++ b/judoscale-rails/lib/judoscale/rails.rb
@@ -8,5 +8,5 @@ require "rails/version"
 
 Judoscale.add_adapter :"judoscale-rails", {
   adapter_version: Judoscale::VERSION,
-  framework_version: ::Rails.version
+  runtime_version: ::Rails.version
 }, metrics_collector: Judoscale::WebMetricsCollector

--- a/judoscale-resque/lib/judoscale/resque.rb
+++ b/judoscale-resque/lib/judoscale/resque.rb
@@ -10,7 +10,7 @@ require "judoscale/resque/latency_extension"
 Judoscale.add_adapter :"judoscale-resque",
   {
     adapter_version: Judoscale::VERSION,
-    framework_version: ::Resque::VERSION
+    runtime_version: ::Resque::VERSION
   },
   metrics_collector: Judoscale::Resque::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:resque)

--- a/judoscale-ruby/lib/judoscale-ruby.rb
+++ b/judoscale-ruby/lib/judoscale-ruby.rb
@@ -33,7 +33,7 @@ module Judoscale
 
   add_adapter :"judoscale-ruby", {
     adapter_version: VERSION,
-    language_version: RUBY_VERSION
+    runtime_version: RUBY_VERSION
   }
 end
 

--- a/judoscale-shoryuken/lib/judoscale/shoryuken.rb
+++ b/judoscale-shoryuken/lib/judoscale/shoryuken.rb
@@ -9,7 +9,7 @@ require "shoryuken"
 Judoscale.add_adapter :"judoscale-shoryuken",
   {
     adapter_version: Judoscale::VERSION,
-    framework_version: ::Shoryuken::VERSION
+    runtime_version: ::Shoryuken::VERSION
   },
   metrics_collector: Judoscale::Shoryuken::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:shoryuken, support_busy_jobs: false)

--- a/judoscale-sidekiq/lib/judoscale/sidekiq.rb
+++ b/judoscale-sidekiq/lib/judoscale/sidekiq.rb
@@ -9,7 +9,7 @@ require "sidekiq/api"
 Judoscale.add_adapter :"judoscale-sidekiq",
   {
     adapter_version: Judoscale::VERSION,
-    framework_version: ::Sidekiq::VERSION
+    runtime_version: ::Sidekiq::VERSION
   },
   metrics_collector: Judoscale::Sidekiq::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:sidekiq)

--- a/judoscale-solid_queue/lib/judoscale/solid_queue.rb
+++ b/judoscale-solid_queue/lib/judoscale/solid_queue.rb
@@ -9,7 +9,7 @@ require "judoscale/solid_queue/metrics_collector"
 Judoscale.add_adapter :"judoscale-solid_queue",
   {
     adapter_version: Judoscale::VERSION,
-    framework_version: ::SolidQueue::VERSION
+    runtime_version: ::SolidQueue::VERSION
   },
   metrics_collector: Judoscale::SolidQueue::MetricsCollector,
   expose_config: Judoscale::Config::JobAdapterConfig.new(:solid_queue)


### PR DESCRIPTION
This is being updated on all packages to keep everything consistent.

- Ruby: https://github.com/judoscale/judoscale-ruby/pull/264
- Python: https://github.com/judoscale/judoscale-python/pull/125
- Node: https://github.com/judoscale/judoscale-node/pull/94
- Java: https://github.com/judoscale/judoscale-java/pull/9