### PR TITLE
Add a backoff to API retries

### DIFF
--- a/judoscale-ruby/lib/judoscale/adapter_api.rb
+++ b/judoscale-ruby/lib/judoscale/adapter_api.rb
@@ -53,7 +53,7 @@ module Judoscale
     rescue *TRANSIENT_ERRORS => ex
       if attempts < 3
         # TCP timeouts happen sometimes, but they can usually be successfully retried in a moment
-        sleep 0.01
+        sleep 0.25 * (2**(attempts - 1))
         attempts += 1
         retry
       else


### PR DESCRIPTION
The API retries exist for transient network issues, but our 10ms delay isn't always long enough to allow those conditions to resolve.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the retry sleep timing on transient network errors, with the main impact being slightly longer waits before failing when the API is unreachable.
> 
> **Overview**
> Adds exponential backoff to `AdapterApi` transient-error retries by replacing the fixed 10ms delay with a growing sleep (`0.25s`, `0.5s`, …) across up to 3 attempts, improving resilience to brief network issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b3c1d981ec2edca45e09b0ee1e948a4555e373e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->