### PR TITLE
Wrap MetricsCollector initialization in log_exceptions

### DIFF
--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -39,7 +39,14 @@ module Judoscale
 
       logger.info "Reporter starting, will report every ~#{config.report_interval_seconds} seconds (adapters: #{adapters_msg})"
 
-      metrics_collectors = metrics_collectors_classes.map(&:new)
+      metrics_collectors = metrics_collectors_classes.filter_map { |klass|
+        log_exceptions { klass.new }
+      }
+
+      if metrics_collectors.empty?
+        logger.warn "All metrics collectors failed to initialize"
+        return
+      end
 
       run_loop(config, metrics_collectors)
     end


### PR DESCRIPTION
MetricsCollector#initialize can run DB queries (e.g., GoodJob fetches queue names via SELECT distinct queue_name). If the database is under load and the query hits a statement timeout (PG::QueryCanceled), the exception propagates through Reporter#start! and crashes the process.

The collect() method is already wrapped in log_exceptions, but the .new call was not. This applies the same protection to initialization, consistent with how transient errors are handled elsewhere.

If a collector fails to initialize, it's skipped and the reporter continues with the remaining collectors. If all collectors fail, the reporter logs a warning and returns without starting the loop.

Fixes #267