### PR TITLE
Prevent scanning for worker queues on init

### DIFF
--- a/judoscale-good_job/lib/judoscale/good_job/metrics_collector.rb
+++ b/judoscale-good_job/lib/judoscale/good_job/metrics_collector.rb
@@ -27,13 +27,7 @@ module Judoscale
 
       def initialize
         super
-
         @good_job_base_class = self.class.good_job_base_class
-
-        queue_names = run_silently do
-          @good_job_base_class.select("distinct queue_name").map(&:queue_name)
-        end
-        self.queues |= queue_names
       end
 
       def collect

--- a/judoscale-good_job/lib/judoscale/good_job/metrics_collector.rb
+++ b/judoscale-good_job/lib/judoscale/good_job/metrics_collector.rb
@@ -34,6 +34,10 @@ module Judoscale
         metrics = []
         time = Time.now.utc
 
+        if queues.empty?
+          self.queues |= run_silently { @good_job_base_class.distinct.pluck(:queue_name) }
+        end
+
         # logically we don't need the finished_at condition, but it lets postgres use the indexes
         oldest_execution_time_by_queue = run_silently do
           @good_job_base_class

--- a/judoscale-good_job/test/metrics_collector_test.rb
+++ b/judoscale-good_job/test/metrics_collector_test.rb
@@ -54,13 +54,11 @@ module Judoscale
 
       it "always collects for known queues" do
         Delayable.set(queue: "high").perform_later
-        ::GoodJob::JobPerformer.new("high").next
 
         metrics = subject.collect
 
         _(metrics.size).must_equal 1
         _(metrics[0].queue_name).must_equal "high"
-        _(metrics[0].value).must_equal 0
 
         Delayable.set(queue: "default").perform_later
 

--- a/judoscale-solid_queue/lib/judoscale/solid_queue/metrics_collector.rb
+++ b/judoscale-solid_queue/lib/judoscale/solid_queue/metrics_collector.rb
@@ -21,6 +21,10 @@ module Judoscale
         metrics = []
         time = Time.now.utc
 
+        if queues.empty?
+          self.queues |= run_silently { ::SolidQueue::Job.distinct.pluck(:queue_name) }
+        end
+
         oldest_execution_time_by_queue = run_silently do
           ::SolidQueue::ReadyExecution.group(:queue_name).minimum(:created_at)
         end

--- a/judoscale-solid_queue/lib/judoscale/solid_queue/metrics_collector.rb
+++ b/judoscale-solid_queue/lib/judoscale/solid_queue/metrics_collector.rb
@@ -17,15 +17,6 @@ module Judoscale
         super && ActiveRecordHelper.table_exists_for_model?(::SolidQueue::Job)
       end
 
-      def initialize
-        super
-
-        queue_names = run_silently do
-          ::SolidQueue::Job.distinct.pluck(:queue_name)
-        end
-        self.queues |= queue_names
-      end
-
       def collect
         metrics = []
         time = Time.now.utc

--- a/judoscale-solid_queue/test/metrics_collector_test.rb
+++ b/judoscale-solid_queue/test/metrics_collector_test.rb
@@ -104,9 +104,7 @@ module Judoscale
 
         metrics = subject.collect
 
-        _(metrics.size).must_equal 1
-        _(metrics[0].queue_name).must_equal "default"
-        _(metrics[0].value).must_equal 0
+        _(metrics).must_be :empty?
       end
 
       it "ignores claimed jobs being processed" do
@@ -119,9 +117,7 @@ module Judoscale
 
         metrics = subject.collect
 
-        _(metrics.size).must_equal 1
-        _(metrics[0].queue_name).must_equal "default"
-        _(metrics[0].value).must_equal 0
+        _(metrics).must_be :empty?
       end
 
       it "ignores failed jobs waiting on retry (re-scheduled via Active Job)" do
@@ -134,9 +130,7 @@ module Judoscale
 
         metrics = subject.collect
 
-        _(metrics.size).must_equal 1
-        _(metrics[0].queue_name).must_equal "default"
-        _(metrics[0].value).must_equal 0
+        _(metrics).must_be :empty?
       end
 
       it "ignores failed jobs" do
@@ -154,9 +148,7 @@ module Judoscale
 
         metrics = subject.collect
 
-        _(metrics.size).must_equal 1
-        _(metrics[0].queue_name).must_equal "default"
-        _(metrics[0].value).must_equal 0
+        _(metrics).must_be :empty?
       end
 
       it "collects metrics for jobs without a queue name" do

--- a/judoscale-solid_queue/test/metrics_collector_test.rb
+++ b/judoscale-solid_queue/test/metrics_collector_test.rb
@@ -104,7 +104,9 @@ module Judoscale
 
         metrics = subject.collect
 
-        _(metrics).must_be :empty?
+        _(metrics.size).must_equal 1
+        _(metrics[0].queue_name).must_equal "default"
+        _(metrics[0].value).must_equal 0
       end
 
       it "ignores claimed jobs being processed" do
@@ -117,7 +119,9 @@ module Judoscale
 
         metrics = subject.collect
 
-        _(metrics).must_be :empty?
+        _(metrics.size).must_equal 1
+        _(metrics[0].queue_name).must_equal "default"
+        _(metrics[0].value).must_equal 0
       end
 
       it "ignores failed jobs waiting on retry (re-scheduled via Active Job)" do
@@ -130,7 +134,9 @@ module Judoscale
 
         metrics = subject.collect
 
-        _(metrics).must_be :empty?
+        _(metrics.size).must_equal 1
+        _(metrics[0].queue_name).must_equal "default"
+        _(metrics[0].value).must_equal 0
       end
 
       it "ignores failed jobs" do
@@ -148,7 +154,9 @@ module Judoscale
 
         metrics = subject.collect
 
-        _(metrics).must_be :empty?
+        _(metrics.size).must_equal 1
+        _(metrics[0].queue_name).must_equal "default"
+        _(metrics[0].value).must_equal 0
       end
 
       it "collects metrics for jobs without a queue name" do


### PR DESCRIPTION
Connecting to the DB or Redis on init might be problematic if that connection / query can't be quickly executed, or raises an exception / times out, because it could crash the reporter and with it the whole process.

This eliminates the init methods, and leave the queue discovery to the collection time, which already runs inside the reporter thread, and are wrapped in proper exception handling.

Another benefit of leaving this to the collection time is that we should have faster init/boot time for GoodJob & SolidQueue adapters.

Closes https://github.com/judoscale/judoscale-ruby/issues/267
Closes https://github.com/judoscale/judoscale-ruby/pull/268

Ref.: https://github.com/judoscale/judoscale-python/pull/131