### PR TITLE
fix: Read Scalingo container identity from CONTAINER env var

### DIFF
--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -125,6 +125,9 @@ module Judoscale
           RuntimeContainer.new ENV["FLY_MACHINE_ID"]
         elsif ENV.include?("RAILWAY_REPLICA_ID")
           RuntimeContainer.new ENV["RAILWAY_REPLICA_ID"]
+        elsif ENV.include?("CONTAINER")
+          # Scalingo exposes the container type and index (e.g. "web-1") via CONTAINER.
+          RuntimeContainer.new ENV["CONTAINER"]
         else
           # Unsupported platform...
           RuntimeContainer.new("")

--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -6,13 +6,14 @@ require "logger"
 module Judoscale
   class Config
     class RuntimeContainer < String
-      # Since Heroku exposes ordinal dyno 'numbers', we can tell if the current
-      # instance is redundant (and thus skip collecting some metrics sometimes)
-      # We don't have a means of determining that on Render though — so every
-      # instance must be considered non-redundant
+      # Job metrics are collected from a single container per process type when we
+      # can identify the ordinal instance (Heroku "web.2", Scalingo "web-2").
+      # Opaque IDs (Render, ECS, Railway, etc.) are always non-redundant.
+      ORDINAL_CONTAINER = /\A[a-z_]+[.-](\d{1,3})\z/
+
       def redundant_instance?
-        instance_number = split(".")[1].to_i
-        instance_number > 1
+        match = match(ORDINAL_CONTAINER)
+        match ? match[1].to_i > 1 : false
       end
     end
 

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -129,6 +129,19 @@ module Judoscale
       end
     end
 
+    it "initializes the config from default Scalingo ENV vars" do
+      env = {
+        "CONTAINER" => "web-1",
+        "JUDOSCALE_URL" => "https://adapter.judoscale.com/api/1234567890"
+      }
+
+      use_env env do
+        config = Config.instance
+        _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
+        _(config.current_runtime_container).must_equal "web-1"
+      end
+    end
+
     it "allows ENV vars config overrides for the debug and URL" do
       env = {
         "DYNO" => "web.2",

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -142,6 +142,21 @@ module Judoscale
       end
     end
 
+    describe Config::RuntimeContainer do
+      it "treats only ordinal instances beyond the first as redundant when the id format is known" do
+        _(Config::RuntimeContainer.new("web.1").redundant_instance?).must_equal false
+        _(Config::RuntimeContainer.new("web.2").redundant_instance?).must_equal true
+        _(Config::RuntimeContainer.new("web-1").redundant_instance?).must_equal false
+        _(Config::RuntimeContainer.new("web-2").redundant_instance?).must_equal true
+      end
+
+      it "does not treat opaque container ids as redundant" do
+        _(Config::RuntimeContainer.new("5497f74465-m5wwr").redundant_instance?).must_equal false
+        _(Config::RuntimeContainer.new("a8880ee042bc4db3ba878dce65b769b6-2750272591").redundant_instance?).must_equal false
+        _(Config::RuntimeContainer.new("abcdef-2750272591").redundant_instance?).must_equal false
+      end
+    end
+
     it "allows ENV vars config overrides for the debug and URL" do
       env = {
         "DYNO" => "web.2",

--- a/judoscale-ruby/test/job_metrics_collector_test.rb
+++ b/judoscale-ruby/test/job_metrics_collector_test.rb
@@ -12,6 +12,9 @@ module Judoscale
           web.1
           worker.1
           custom_name.1
+          web-1
+          worker-1
+          tcp-1
           5497f74465-m5wwr
           aaacff2165-m5wwr
         ].each do |container_id|
@@ -26,6 +29,9 @@ module Judoscale
           web.2
           worker.8
           custom_name.15
+          web-2
+          worker-8
+          tcp-2
         ].each do |container_id|
           Judoscale.configure do |config|
             config.current_runtime_container = Config::RuntimeContainer.new(container_id)


### PR DESCRIPTION
## Summary

- Detect `current_runtime_container` from Scalingo’s runtime `CONTAINER` env var (e.g. `web-1`, `worker-1`) so adapter reports include container metadata instead of `[missing]`.
- Treat Scalingo ordinal containers beyond the first (e.g. `web-2`, `worker-8`) as redundant for job metrics collection, matching the existing Heroku behavior.
- Keep opaque container IDs non-redundant, including IDs with long numeric suffixes.

## Test plan

- [x] `bundle exec ruby -Itest test/config_test.rb -n "/Scalingo/"` passes with the implementation
- [x] Same test fails (expects `web-1`, gets `""`) when the `CONTAINER` branch is removed
- [x] `bundle exec ruby -Itest test/config_test.rb -n "/opaque container ids/"` fails before constraining ordinals to 1-3 digits, then passes after the regex update
- [x] `bundle exec ruby -Itest test/config_test.rb test/job_metrics_collector_test.rb` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Platform detection and metrics-collection gating only; no auth or data-path changes, with behavior aligned to existing Heroku rules plus new tests.
> 
> **Overview**
> Adds **Scalingo** support by reading `current_runtime_container` from the runtime `CONTAINER` env var (e.g. `web-1`), so adapter reports include real container metadata instead of an empty value.
> 
> **Redundant-instance detection** for job metrics is generalized: `RuntimeContainer#redundant_instance?` now uses an `ORDINAL_CONTAINER` pattern that accepts Heroku-style (`web.2`) and Scalingo-style (`web-2`) ordinals, still skipping collection on instances beyond the first. Opaque IDs (Render, ECS, Railway, etc.) stay non-redundant; the ordinal suffix is capped at **1–3 digits** so long numeric tails on opaque IDs are not mistaken for scale indices.
> 
> Tests cover Scalingo config init, redundant vs opaque IDs, and job collector behavior for `web-1` / `web-2` style names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13db7e93f8a9fb1a3efcbf7c9fc15c69489b2147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->