### PR TITLE
fix: skip the reporter in one-off containers

### DIFF
--- a/judoscale-rails/lib/judoscale/rails/railtie.rb
+++ b/judoscale-rails/lib/judoscale/rails/railtie.rb
@@ -27,6 +27,10 @@ module Judoscale
         top_level_tasks.any? { |task| task_regex.match?(task) }
       end
 
+      def in_one_off_container?
+        judoscale_config.current_runtime_container.one_off?
+      end
+
       def judoscale_config
         # Disambiguate from Judoscale::Rails::Config
         ::Judoscale::Config.instance
@@ -43,6 +47,8 @@ module Judoscale
       config.after_initialize do
         if in_rails_console_or_runner?
           logger.debug "No reporting since we're in a Rails console or runner process"
+        elsif in_one_off_container?
+          logger.debug "No reporting since we're in a one-off container"
         elsif in_rake_task?(judoscale_config.rake_task_ignore_regex)
           logger.debug "No reporting since we're in a build process"
         elsif judoscale_config.start_reporter_after_initialize

--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -11,9 +11,18 @@ module Judoscale
       # Opaque IDs (Render, ECS, Railway, etc.) are always non-redundant.
       ORDINAL_CONTAINER = /\A[a-z_]+[.-](\d{1,3})\z/
 
+      # One-off containers (Heroku "run.1234", Scalingo "one-off-1234") are never
+      # part of an autoscaled formation, so there's no point reporting metrics from
+      # them — they only duplicate queue metrics already sent by the workers.
+      ONE_OFF_CONTAINER = /\A(run\.|one-off)/
+
       def redundant_instance?
         match = match(ORDINAL_CONTAINER)
         match ? match[1].to_i > 1 : false
+      end
+
+      def one_off?
+        match?(ONE_OFF_CONTAINER)
       end
     end
 

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -155,6 +155,19 @@ module Judoscale
         _(Config::RuntimeContainer.new("a8880ee042bc4db3ba878dce65b769b6-2750272591").redundant_instance?).must_equal false
         _(Config::RuntimeContainer.new("abcdef-2750272591").redundant_instance?).must_equal false
       end
+
+      it "treats Heroku and Scalingo one-off containers as one-off" do
+        _(Config::RuntimeContainer.new("run.1234").one_off?).must_equal true
+        _(Config::RuntimeContainer.new("one-off-1234").one_off?).must_equal true
+      end
+
+      it "does not treat formation containers as one-off" do
+        _(Config::RuntimeContainer.new("web.1").one_off?).must_equal false
+        _(Config::RuntimeContainer.new("web-1").one_off?).must_equal false
+        _(Config::RuntimeContainer.new("worker-2").one_off?).must_equal false
+        _(Config::RuntimeContainer.new("runner-1").one_off?).must_equal false
+        _(Config::RuntimeContainer.new("5497f74465-m5wwr").one_off?).must_equal false
+      end
     end
 
     it "allows ENV vars config overrides for the debug and URL" do


### PR DESCRIPTION
## Summary

One-off containers (Heroku `run.1234`, Scalingo `one-off-1234`) are never part of an autoscaled formation, but the reporter still boots in them and reports queue metrics for the whole life of the process. Those metrics just duplicate what the workers already send.

The existing guards only catch specific commands, not one-off containers:

- `in_rails_console_or_runner?` (#192, #217) catches only `rails console` and `rails runner`
- `rake_task_ignore_regex = /assets:|db:/` (#180, #220) catches only build/deploy rake tasks

So a one-off that runs a business rake task (outside `assets:`/`db:`) or a plain script that boots Rails falls through and starts the reporter. Container identity is now available on both Scalingo (#271) and Heroku, so we can detect one-off containers directly.

## Changes

- Add `RuntimeContainer#one_off?`, matching Heroku `run.*` and Scalingo `one-off*`.
- Skip starting the reporter in one-off containers, next to the existing console/runner/build guards in the railtie.

## Test plan

- [x] `bundle exec ruby -Itest test/config_test.rb` (judoscale-ruby): new `one_off?` cases pass (23 runs, 0 failures)
- [x] `bundle exec ruby -Itest test/railtie_test.rb test/config_test.rb` (judoscale-rails): the reporter still boots outside one-off containers (3 runs, 0 failures)
- [x] `standardrb` clean on the changed files

Scope is the Rails railtie, same as the existing guards. Other adapters are unaffected.
