### PR TITLE
refactor: Model the hosting platform with per-platform classes

### DIFF
--- a/judoscale-rails/lib/judoscale/rails/railtie.rb
+++ b/judoscale-rails/lib/judoscale/rails/railtie.rb
@@ -28,7 +28,7 @@ module Judoscale
       end
 
       def in_one_off_container?
-        judoscale_config.current_runtime_container.one_off?
+        judoscale_config.current_platform.one_off?
       end
 
       def judoscale_config

--- a/judoscale-ruby/lib/judoscale/config.rb
+++ b/judoscale-ruby/lib/judoscale/config.rb
@@ -2,30 +2,10 @@
 
 require "singleton"
 require "logger"
+require "judoscale/platform"
 
 module Judoscale
   class Config
-    class RuntimeContainer < String
-      # Job metrics are collected from a single container per process type when we
-      # can identify the ordinal instance (Heroku "web.2", Scalingo "web-2").
-      # Opaque IDs (Render, ECS, Railway, etc.) are always non-redundant.
-      ORDINAL_CONTAINER = /\A[a-z_]+[.-](\d{1,3})\z/
-
-      # One-off containers (Heroku "run.1234", Scalingo "one-off-1234") are never
-      # part of an autoscaled formation, so there's no point reporting metrics from
-      # them — they only duplicate queue metrics already sent by the workers.
-      ONE_OFF_CONTAINER = /\A(run\.|one-off)/
-
-      def redundant_instance?
-        match = match(ORDINAL_CONTAINER)
-        match ? match[1].to_i > 1 : false
-      end
-
-      def one_off?
-        match?(ONE_OFF_CONTAINER)
-      end
-    end
-
     class JobAdapterConfig
       UUID_REGEXP = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
       DEFAULT_QUEUE_FILTER = ->(queue_name) { !UUID_REGEXP.match?(queue_name) }
@@ -99,7 +79,7 @@ module Judoscale
     end
 
     attr_accessor :api_base_url, :report_interval_seconds,
-      :max_request_size_bytes, :logger, :log_tag, :current_runtime_container
+      :max_request_size_bytes, :logger, :log_tag, :current_platform
     attr_reader :log_level
 
     def initialize
@@ -117,31 +97,9 @@ module Judoscale
 
       self.class.adapter_configs.each(&:reset)
 
-      @current_runtime_container =
-        if ENV.include?("JUDOSCALE_CONTAINER")
-          RuntimeContainer.new ENV["JUDOSCALE_CONTAINER"]
-        elsif ENV.include?("DYNO")
-          RuntimeContainer.new ENV["DYNO"]
-        elsif ENV.include?("RENDER_INSTANCE_ID")
-          # Deprecated API url using the service ID for legacy render services not using `JUDOSCALE_URL`.
-          @api_base_url ||= "https://adapter.judoscale.com/api/#{ENV["RENDER_SERVICE_ID"]}"
-
-          instance = ENV["RENDER_INSTANCE_ID"].delete_prefix("#{ENV["RENDER_SERVICE_ID"]}-")
-          RuntimeContainer.new instance
-        elsif ENV.include?("ECS_CONTAINER_METADATA_URI")
-          instance = ENV["ECS_CONTAINER_METADATA_URI"].split("/").last
-          RuntimeContainer.new instance
-        elsif ENV.include?("FLY_MACHINE_ID")
-          RuntimeContainer.new ENV["FLY_MACHINE_ID"]
-        elsif ENV.include?("RAILWAY_REPLICA_ID")
-          RuntimeContainer.new ENV["RAILWAY_REPLICA_ID"]
-        elsif ENV.include?("CONTAINER")
-          # Scalingo exposes the container type and index (e.g. "web-1") via CONTAINER.
-          RuntimeContainer.new ENV["CONTAINER"]
-        else
-          # Unsupported platform...
-          RuntimeContainer.new("")
-        end
+      @current_platform = Platform.detect(ENV)
+      # Legacy Render services not using JUDOSCALE_URL derive the API url from the platform.
+      @api_base_url ||= @current_platform.default_api_base_url
     end
 
     def log_level=(new_level)

--- a/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
+++ b/judoscale-ruby/lib/judoscale/job_metrics_collector.rb
@@ -9,7 +9,7 @@ module Judoscale
     include Judoscale::Logger
 
     def self.collect?(config)
-      super && !config.current_runtime_container.redundant_instance? && adapter_config.enabled
+      super && !config.current_platform.redundant_instance? && adapter_config.enabled
     end
 
     def self.adapter_name

--- a/judoscale-ruby/lib/judoscale/platform.rb
+++ b/judoscale-ruby/lib/judoscale/platform.rb
@@ -37,9 +37,7 @@ module Judoscale
       elsif env.include?("DYNO")
         Heroku.new env["DYNO"]
       elsif env.include?("RENDER_INSTANCE_ID")
-        service_id = env["RENDER_SERVICE_ID"]
-        instance = env["RENDER_INSTANCE_ID"].delete_prefix("#{service_id}-")
-        Render.new instance, service_id: service_id
+        Render.new env["RENDER_INSTANCE_ID"], service_id: env["RENDER_SERVICE_ID"]
       elsif env.include?("ECS_CONTAINER_METADATA_URI")
         Ecs.new env["ECS_CONTAINER_METADATA_URI"].split("/").last
       elsif env.include?("FLY_MACHINE_ID")
@@ -83,9 +81,10 @@ module Judoscale
     end
 
     class Render < Platform
-      def initialize(container, service_id:)
-        super(container)
+      def initialize(instance_id, service_id:)
         @service_id = service_id
+        # Render prefixes the instance id with the service id, which isn't part of the instance.
+        super(instance_id.delete_prefix("#{service_id}-"))
       end
 
       # Legacy Render services not using JUDOSCALE_URL derive the adapter URL

--- a/judoscale-ruby/lib/judoscale/platform.rb
+++ b/judoscale-ruby/lib/judoscale/platform.rb
@@ -76,7 +76,7 @@ module Judoscale
 
       # Scalingo one-off containers are named "one-off-1234".
       def one_off?
-        container.start_with?("one-off")
+        container.start_with?("one-off-")
       end
     end
 

--- a/judoscale-ruby/lib/judoscale/platform.rb
+++ b/judoscale-ruby/lib/judoscale/platform.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Judoscale
+  # The hosting platform we detected from the environment. The container/instance
+  # id is just one property of the platform — behavior that only applies to
+  # certain platforms (whether an instance is a redundant member of a formation,
+  # or a one-off task) lives on the platform subclasses that actually have those
+  # concepts, instead of being re-derived from the shape of the container string.
+  class Platform
+    attr_reader :container
+
+    def initialize(container)
+      @container = container.to_s
+    end
+
+    # Most platforms expose opaque, non-ordinal instance ids (Render, ECS, Fly,
+    # Railway, custom), so by default no instance is redundant and none is one-off.
+    # Platforms that have those concepts override these.
+    def redundant_instance?
+      false
+    end
+
+    def one_off?
+      false
+    end
+
+    # Platforms may contribute a default API base url when one isn't configured.
+    def default_api_base_url
+      nil
+    end
+
+    # Detect the current platform from the environment. Order matters: an explicit
+    # JUDOSCALE_CONTAINER always wins, and Unknown is the fallback.
+    def self.detect(env = ENV)
+      if env.include?("JUDOSCALE_CONTAINER")
+        Custom.new env["JUDOSCALE_CONTAINER"]
+      elsif env.include?("DYNO")
+        Heroku.new env["DYNO"]
+      elsif env.include?("RENDER_INSTANCE_ID")
+        service_id = env["RENDER_SERVICE_ID"]
+        instance = env["RENDER_INSTANCE_ID"].delete_prefix("#{service_id}-")
+        Render.new instance, service_id: service_id
+      elsif env.include?("ECS_CONTAINER_METADATA_URI")
+        Ecs.new env["ECS_CONTAINER_METADATA_URI"].split("/").last
+      elsif env.include?("FLY_MACHINE_ID")
+        Fly.new env["FLY_MACHINE_ID"]
+      elsif env.include?("RAILWAY_REPLICA_ID")
+        Railway.new env["RAILWAY_REPLICA_ID"]
+      elsif env.include?("CONTAINER")
+        # Scalingo exposes the container type and index (e.g. "web-1") via CONTAINER.
+        Scalingo.new env["CONTAINER"]
+      else
+        Unknown.new ""
+      end
+    end
+
+    # Heroku dynos are named "web.2". We collect job metrics from a single
+    # container per process type, so any instance beyond the first is redundant —
+    # it would only duplicate the queue metrics the first instance already reports.
+    class Heroku < Platform
+      def redundant_instance?
+        match = container.match(/\A[a-z_]+\.(\d+)\z/)
+        match ? match[1].to_i > 1 : false
+      end
+
+      # Heroku one-off dynos are named "run.1234".
+      def one_off?
+        container.start_with?("run.")
+      end
+    end
+
+    # Scalingo containers are named "web-2", same redundancy rule as Heroku.
+    class Scalingo < Platform
+      def redundant_instance?
+        match = container.match(/\A[a-z_]+-(\d+)\z/)
+        match ? match[1].to_i > 1 : false
+      end
+
+      # Scalingo one-off containers are named "one-off-1234".
+      def one_off?
+        container.start_with?("one-off")
+      end
+    end
+
+    class Render < Platform
+      def initialize(container, service_id:)
+        super(container)
+        @service_id = service_id
+      end
+
+      # Legacy Render services not using JUDOSCALE_URL derive the adapter URL
+      # from the service id.
+      def default_api_base_url
+        "https://adapter.judoscale.com/api/#{@service_id}"
+      end
+    end
+
+    class Ecs < Platform
+    end
+
+    class Fly < Platform
+    end
+
+    class Railway < Platform
+    end
+
+    # User-provided container id via JUDOSCALE_CONTAINER.
+    class Custom < Platform
+    end
+
+    # Unsupported or undetected platform.
+    class Unknown < Platform
+    end
+  end
+end

--- a/judoscale-ruby/lib/judoscale/report.rb
+++ b/judoscale-ruby/lib/judoscale/report.rb
@@ -12,7 +12,7 @@ module Judoscale
 
     def as_json
       {
-        container: config.current_runtime_container,
+        container: config.current_platform.container,
         pid: Process.pid,
         config: config.as_json,
         adapters: adapters.reduce({}) { |hash, adapter| hash.merge!(adapter.as_json) },

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -193,6 +193,10 @@ module Judoscale
         _(Platform::Unknown.new("").one_off?).must_equal false
       end
 
+      it "strips the service id prefix from the Render instance id" do
+        _(Platform::Render.new("srv-x-5497f74465-m5wwr", service_id: "srv-x").container).must_equal "5497f74465-m5wwr"
+      end
+
       it "lets legacy Render services derive the API url from the service id" do
         _(Platform::Render.new("abc", service_id: "srv-x").default_api_base_url).must_equal "https://adapter.judoscale.com/api/srv-x"
         _(Platform::Heroku.new("web.1").default_api_base_url).must_be_nil

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -14,7 +14,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
-        _(config.current_runtime_container).must_equal "web.1"
+        _(config.current_platform.container).must_equal "web.1"
         _(config.log_level).must_be_nil
         _(config.logger).must_be_instance_of ::Logger
         _(config.max_request_size_bytes).must_equal 100_000
@@ -42,7 +42,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/srv-cfa1es5a49987h4vcvfg"
-        _(config.current_runtime_container).must_equal "5497f74465-m5wwr"
+        _(config.current_platform.container).must_equal "5497f74465-m5wwr"
       end
     end
 
@@ -57,7 +57,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
-        _(config.current_runtime_container).must_equal "5497f74465-m5wwr"
+        _(config.current_platform.container).must_equal "5497f74465-m5wwr"
       end
     end
 
@@ -71,7 +71,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
-        _(config.current_runtime_container).must_equal "a8880ee042bc4db3ba878dce65b769b6-2750272591"
+        _(config.current_platform.container).must_equal "a8880ee042bc4db3ba878dce65b769b6-2750272591"
       end
     end
 
@@ -85,7 +85,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
-        _(config.current_runtime_container).must_equal "683d924b322418"
+        _(config.current_platform.container).must_equal "683d924b322418"
       end
     end
 
@@ -99,7 +99,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
-        _(config.current_runtime_container).must_equal "f9c88b6e-0e96-46f2-9884-ece3bf53d009"
+        _(config.current_platform.container).must_equal "f9c88b6e-0e96-46f2-9884-ece3bf53d009"
       end
     end
 
@@ -112,7 +112,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
-        _(config.current_runtime_container).must_equal "custom-container-123"
+        _(config.current_platform.container).must_equal "custom-container-123"
       end
     end
 
@@ -125,7 +125,7 @@ module Judoscale
 
       use_env env do
         config = Config.instance
-        _(config.current_runtime_container).must_equal "custom-container-123"
+        _(config.current_platform.container).must_equal "custom-container-123"
       end
     end
 
@@ -138,35 +138,64 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://adapter.judoscale.com/api/1234567890"
-        _(config.current_runtime_container).must_equal "web-1"
+        _(config.current_platform.container).must_equal "web-1"
       end
     end
 
-    describe Config::RuntimeContainer do
-      it "treats only ordinal instances beyond the first as redundant when the id format is known" do
-        _(Config::RuntimeContainer.new("web.1").redundant_instance?).must_equal false
-        _(Config::RuntimeContainer.new("web.2").redundant_instance?).must_equal true
-        _(Config::RuntimeContainer.new("web-1").redundant_instance?).must_equal false
-        _(Config::RuntimeContainer.new("web-2").redundant_instance?).must_equal true
+    describe Platform do
+      it "detects the platform from environment variables, JUDOSCALE_CONTAINER winning over platform vars" do
+        _(Platform.detect("JUDOSCALE_CONTAINER" => "x", "DYNO" => "web.1")).must_be_instance_of Platform::Custom
+        _(Platform.detect("DYNO" => "web.1")).must_be_instance_of Platform::Heroku
+        _(Platform.detect("RENDER_INSTANCE_ID" => "srv-x-abc", "RENDER_SERVICE_ID" => "srv-x")).must_be_instance_of Platform::Render
+        _(Platform.detect("ECS_CONTAINER_METADATA_URI" => "http://169.254.170.2/v3/abc")).must_be_instance_of Platform::Ecs
+        _(Platform.detect("FLY_MACHINE_ID" => "683d924b322418")).must_be_instance_of Platform::Fly
+        _(Platform.detect("RAILWAY_REPLICA_ID" => "f9c88b6e")).must_be_instance_of Platform::Railway
+        _(Platform.detect("CONTAINER" => "web-1")).must_be_instance_of Platform::Scalingo
+        _(Platform.detect({})).must_be_instance_of Platform::Unknown
       end
 
-      it "does not treat opaque container ids as redundant" do
-        _(Config::RuntimeContainer.new("5497f74465-m5wwr").redundant_instance?).must_equal false
-        _(Config::RuntimeContainer.new("a8880ee042bc4db3ba878dce65b769b6-2750272591").redundant_instance?).must_equal false
-        _(Config::RuntimeContainer.new("abcdef-2750272591").redundant_instance?).must_equal false
+      it "treats only ordinal instances beyond the first as redundant on Heroku and Scalingo" do
+        _(Platform::Heroku.new("web.1").redundant_instance?).must_equal false
+        _(Platform::Heroku.new("web.2").redundant_instance?).must_equal true
+        _(Platform::Scalingo.new("web-1").redundant_instance?).must_equal false
+        _(Platform::Scalingo.new("web-2").redundant_instance?).must_equal true
+      end
+
+      it "handles large formations without capping the ordinal width" do
+        _(Platform::Heroku.new("web.1000").redundant_instance?).must_equal true
+        _(Platform::Scalingo.new("worker-1024").redundant_instance?).must_equal true
+      end
+
+      it "never treats opaque-id platforms as redundant" do
+        _(Platform::Render.new("5497f74465-m5wwr", service_id: "srv-x").redundant_instance?).must_equal false
+        _(Platform::Ecs.new("a8880ee042bc4db3ba878dce65b769b6-2750272591").redundant_instance?).must_equal false
+        _(Platform::Fly.new("683d924b322418").redundant_instance?).must_equal false
+        _(Platform::Railway.new("f9c88b6e-0e96-46f2-9884-ece3bf53d009").redundant_instance?).must_equal false
+        _(Platform::Custom.new("abcdef-2750272591").redundant_instance?).must_equal false
+        _(Platform::Unknown.new("").redundant_instance?).must_equal false
       end
 
       it "treats Heroku and Scalingo one-off containers as one-off" do
-        _(Config::RuntimeContainer.new("run.1234").one_off?).must_equal true
-        _(Config::RuntimeContainer.new("one-off-1234").one_off?).must_equal true
+        _(Platform::Heroku.new("run.1234").one_off?).must_equal true
+        _(Platform::Scalingo.new("one-off-1234").one_off?).must_equal true
       end
 
       it "does not treat formation containers as one-off" do
-        _(Config::RuntimeContainer.new("web.1").one_off?).must_equal false
-        _(Config::RuntimeContainer.new("web-1").one_off?).must_equal false
-        _(Config::RuntimeContainer.new("worker-2").one_off?).must_equal false
-        _(Config::RuntimeContainer.new("runner-1").one_off?).must_equal false
-        _(Config::RuntimeContainer.new("5497f74465-m5wwr").one_off?).must_equal false
+        _(Platform::Heroku.new("web.1").one_off?).must_equal false
+        _(Platform::Scalingo.new("web-1").one_off?).must_equal false
+        _(Platform::Scalingo.new("worker-2").one_off?).must_equal false
+        _(Platform::Heroku.new("runner-1").one_off?).must_equal false
+      end
+
+      it "never treats opaque-id platforms as one-off" do
+        _(Platform::Render.new("5497f74465-m5wwr", service_id: "srv-x").one_off?).must_equal false
+        _(Platform::Fly.new("683d924b322418").one_off?).must_equal false
+        _(Platform::Unknown.new("").one_off?).must_equal false
+      end
+
+      it "lets legacy Render services derive the API url from the service id" do
+        _(Platform::Render.new("abc", service_id: "srv-x").default_api_base_url).must_equal "https://adapter.judoscale.com/api/srv-x"
+        _(Platform::Heroku.new("web.1").default_api_base_url).must_be_nil
       end
     end
 
@@ -180,7 +209,7 @@ module Judoscale
       use_env env do
         config = Config.instance
         _(config.api_base_url).must_equal "https://custom.example.com"
-        _(config.current_runtime_container).must_equal "web.2"
+        _(config.current_platform.container).must_equal "web.2"
         _(config.log_level).must_equal ::Logger::Severity::DEBUG
       end
     end
@@ -228,7 +257,7 @@ module Judoscale
       test_logger = ::Logger.new(StringIO.new)
 
       Judoscale.configure do |config|
-        config.current_runtime_container = Config::RuntimeContainer.new("web.3")
+        config.current_platform = Platform::Heroku.new("web.3")
 
         config.api_base_url = "https://block.example.com"
         config.log_level = :info
@@ -242,7 +271,7 @@ module Judoscale
 
       config = Config.instance
       _(config.api_base_url).must_equal "https://block.example.com"
-      _(config.current_runtime_container).must_equal "web.3"
+      _(config.current_platform.container).must_equal "web.3"
       _(config.log_level).must_equal ::Logger::Severity::INFO
       _(config.logger).must_equal test_logger
       _(config.max_request_size_bytes).must_equal 50_000

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -159,9 +159,6 @@ module Judoscale
         _(Platform::Heroku.new("web.2").redundant_instance?).must_equal true
         _(Platform::Scalingo.new("web-1").redundant_instance?).must_equal false
         _(Platform::Scalingo.new("web-2").redundant_instance?).must_equal true
-      end
-
-      it "handles large formations without capping the ordinal width" do
         _(Platform::Heroku.new("web.1000").redundant_instance?).must_equal true
         _(Platform::Scalingo.new("worker-1024").redundant_instance?).must_equal true
       end

--- a/judoscale-ruby/test/job_metrics_collector_test.rb
+++ b/judoscale-ruby/test/job_metrics_collector_test.rb
@@ -8,33 +8,34 @@ module Judoscale
   describe JobMetricsCollector do
     describe ".collect?" do
       it "collects only from the first container in the formation (if we know that), to avoid redundant collection from multiple containers when possible" do
-        %w[
-          web.1
-          worker.1
-          custom_name.1
-          web-1
-          worker-1
-          tcp-1
-          5497f74465-m5wwr
-          aaacff2165-m5wwr
-        ].each do |container_id|
+        [
+          Platform::Heroku.new("web.1"),
+          Platform::Heroku.new("worker.1"),
+          Platform::Heroku.new("custom_name.1"),
+          Platform::Scalingo.new("web-1"),
+          Platform::Scalingo.new("worker-1"),
+          Platform::Scalingo.new("tcp-1"),
+          # Opaque-id platforms can't identify an ordinal, so they always collect.
+          Platform::Render.new("5497f74465-m5wwr", service_id: "srv-x"),
+          Platform::Ecs.new("aaacff2165-m5wwr")
+        ].each do |platform|
           Judoscale.configure do |config|
-            config.current_runtime_container = Config::RuntimeContainer.new(container_id)
+            config.current_platform = platform
           end
 
           _(Test::TestJobMetricsCollector.collect?(Judoscale::Config.instance)).must_equal true
         end
 
-        %w[
-          web.2
-          worker.8
-          custom_name.15
-          web-2
-          worker-8
-          tcp-2
-        ].each do |container_id|
+        [
+          Platform::Heroku.new("web.2"),
+          Platform::Heroku.new("worker.8"),
+          Platform::Heroku.new("custom_name.15"),
+          Platform::Scalingo.new("web-2"),
+          Platform::Scalingo.new("worker-8"),
+          Platform::Scalingo.new("tcp-2")
+        ].each do |platform|
           Judoscale.configure do |config|
-            config.current_runtime_container = Config::RuntimeContainer.new(container_id)
+            config.current_platform = platform
           end
 
           _(Test::TestJobMetricsCollector.collect?(Judoscale::Config.instance)).must_equal false
@@ -43,7 +44,7 @@ module Judoscale
 
       it "skips collecting if the adapter has been explicitly disabled" do
         Judoscale.configure { |config|
-          config.current_runtime_container = Config::RuntimeContainer.new("web.1")
+          config.current_platform = Platform::Heroku.new("web.1")
           config.test_job_config.enabled = true
         }
 

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -8,7 +8,7 @@ module Judoscale
   describe Reporter do
     before {
       Judoscale.configure do |config|
-        config.current_runtime_container = Config::RuntimeContainer.new("web.1")
+        config.current_platform = Platform::Heroku.new("web.1")
         config.api_base_url = "http://example.com/api/test-token"
       end
     }
@@ -86,7 +86,7 @@ module Judoscale
 
       it "initializes the reporter only with registered web metrics collectors on subsequent runtime containers to avoid redundant worker metrics" do
         Judoscale.configure do |config|
-          config.current_runtime_container = Config::RuntimeContainer.new("web.2")
+          config.current_platform = Platform::Heroku.new("web.2")
         end
 
         run_loop_stub = proc do |config, metrics_collectors|


### PR DESCRIPTION
## Summary

Follows up on @carlosantoniodasilva's suggestion in #273: model the hosting platform as a first-class concept instead of a bare "runtime container" string, and put platform-specific behavior on the platform classes that actually have those concepts.

- Replace `Config::RuntimeContainer` (a `String` subclass) with a `Judoscale::Platform` hierarchy detected from the environment via `Platform.detect`.
- Platform-specific checks live on the platforms that have them: `Heroku` and `Scalingo` implement `redundant_instance?`/`one_off?`; opaque-id platforms (`Render`, `Fly`, `Ecs`, `Railway`, `Custom`, `Unknown`) inherit no-op defaults. This removes the old reliance on a shared regex that only coincidentally didn't match opaque instance ids — those platforms now simply can't be misclassified as redundant or one-off.
- `Config#current_runtime_container` is replaced by `Config#current_platform` (the container id is `current_platform.container`, still reported under the `container` JSON key). The old accessor was undocumented and effectively internal, so it's removed rather than shimmed.
- Drop the `\d{1,3}` ordinal-width cap now that detection already proves the platform is Heroku/Scalingo; `\d+` also correctly classifies formations with 1000+ instances.

## Test plan

- [x] `bundle exec rake test` (judoscale-ruby): 110 runs, 0 failures
- [x] `bundle exec rake test` (judoscale-rails): 7 runs, 0 failures
- [x] `standardrb` clean on changed files
- [ ] CI green across adapter gems

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how job metrics are skipped on redundant dynos and how platforms are detected; behavior is meant to stay equivalent but affects core reporting paths and removes the internal `current_runtime_container` API.
> 
> **Overview**
> Replaces the string-based `Config::RuntimeContainer` with a **`Judoscale::Platform`** model detected via `Platform.detect(ENV)`. **`Config#current_platform`** holds the detected platform; the reported **`container`** value is **`current_platform.container`** (unchanged JSON shape).
> 
> **Heroku** and **Scalingo** now own **`redundant_instance?`** and **`one_off?`**; opaque-id platforms (**Render**, **ECS**, **Fly**, **Railway**, **Custom**, **Unknown**) default both to false instead of inferring from shared container-string regexes. **Render** also supplies **`default_api_base_url`** when `JUDOSCALE_URL` is unset (legacy adapter URL). Ordinal redundancy matching drops the old **3-digit cap** in favor of **`\d+`** (e.g. `web.1000` counts as redundant).
> 
> Call sites switch from **`current_runtime_container`** to **`current_platform`** for job metric collection gating, one-off Rails reporting skips, and report payloads. The undocumented **`current_runtime_container`** accessor is removed without a shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac02199d4825bc66e34a9e38bc8e836a34c188cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->