### PR TITLE
fix: treat ephemeral containers consistently

### DIFF
--- a/judoscale-rails/lib/judoscale/rails/railtie.rb
+++ b/judoscale-rails/lib/judoscale/rails/railtie.rb
@@ -27,10 +27,6 @@ module Judoscale
         top_level_tasks.any? { |task| task_regex.match?(task) }
       end
 
-      def in_one_off_container?
-        judoscale_config.current_platform.one_off?
-      end
-
       def judoscale_config
         # Disambiguate from Judoscale::Rails::Config
         ::Judoscale::Config.instance
@@ -47,8 +43,6 @@ module Judoscale
       config.after_initialize do
         if in_rails_console_or_runner?
           logger.debug "No reporting since we're in a Rails console or runner process"
-        elsif in_one_off_container?
-          logger.debug "No reporting since we're in a one-off container"
         elsif in_rake_task?(judoscale_config.rake_task_ignore_regex)
           logger.debug "No reporting since we're in a build process"
         elsif judoscale_config.start_reporter_after_initialize

--- a/judoscale-ruby/lib/judoscale/platform.rb
+++ b/judoscale-ruby/lib/judoscale/platform.rb
@@ -4,8 +4,9 @@ module Judoscale
   # The hosting platform we detected from the environment. The container/instance
   # id is just one property of the platform — behavior that only applies to
   # certain platforms (whether an instance is a redundant member of a formation,
-  # or a one-off task) lives on the platform subclasses that actually have those
-  # concepts, instead of being re-derived from the shape of the container string.
+  # or an ephemeral process) lives on the platform subclasses that actually have
+  # those concepts, instead of being re-derived from the shape of the container
+  # string.
   class Platform
     attr_reader :container
 
@@ -14,13 +15,13 @@ module Judoscale
     end
 
     # Most platforms expose opaque, non-ordinal instance ids (Render, ECS, Fly,
-    # Railway, custom), so by default no instance is redundant and none is one-off.
+    # Railway, custom), so by default no instance is redundant or ephemeral.
     # Platforms that have those concepts override these.
     def redundant_instance?
       false
     end
 
-    def one_off?
+    def ephemeral_instance?
       false
     end
 
@@ -61,9 +62,9 @@ module Judoscale
         match ? match[1].to_i > 1 : false
       end
 
-      # Heroku one-off dynos are named "run.1234".
-      def one_off?
-        container.start_with?("run.")
+      # Heroku release phase and one-off dynos are named "release.1234" and "run.1234".
+      def ephemeral_instance?
+        container.downcase.start_with?("release.") || container.start_with?("run.")
       end
     end
 
@@ -75,7 +76,7 @@ module Judoscale
       end
 
       # Scalingo one-off containers are named "one-off-1234".
-      def one_off?
+      def ephemeral_instance?
         container.start_with?("one-off-")
       end
     end

--- a/judoscale-ruby/lib/judoscale/reporter.rb
+++ b/judoscale-ruby/lib/judoscale/reporter.rb
@@ -19,6 +19,11 @@ module Judoscale
     def start!(config, adapters)
       @pid = Process.pid
 
+      if config.current_platform.ephemeral_instance?
+        logger.debug "Reporter not started: in an ephemeral container"
+        return
+      end
+
       if config.api_base_url.nil? || config.api_base_url.strip.empty?
         logger.debug "Set api_base_url to enable metrics reporting"
         return

--- a/judoscale-ruby/test/config_test.rb
+++ b/judoscale-ruby/test/config_test.rb
@@ -172,22 +172,28 @@ module Judoscale
         _(Platform::Unknown.new("").redundant_instance?).must_equal false
       end
 
-      it "treats Heroku and Scalingo one-off containers as one-off" do
-        _(Platform::Heroku.new("run.1234").one_off?).must_equal true
-        _(Platform::Scalingo.new("one-off-1234").one_off?).must_equal true
+      it "treats Heroku release phase and one-off dynos as ephemeral instances" do
+        _(Platform::Heroku.new("release.1").ephemeral_instance?).must_equal true
+        _(Platform::Heroku.new("Release.1234").ephemeral_instance?).must_equal true
+        _(Platform::Heroku.new("run.1234").ephemeral_instance?).must_equal true
       end
 
-      it "does not treat formation containers as one-off" do
-        _(Platform::Heroku.new("web.1").one_off?).must_equal false
-        _(Platform::Scalingo.new("web-1").one_off?).must_equal false
-        _(Platform::Scalingo.new("worker-2").one_off?).must_equal false
-        _(Platform::Heroku.new("runner-1").one_off?).must_equal false
+      it "treats Scalingo one-off containers as ephemeral instances" do
+        _(Platform::Scalingo.new("one-off-1234").ephemeral_instance?).must_equal true
       end
 
-      it "never treats opaque-id platforms as one-off" do
-        _(Platform::Render.new("5497f74465-m5wwr", service_id: "srv-x").one_off?).must_equal false
-        _(Platform::Fly.new("683d924b322418").one_off?).must_equal false
-        _(Platform::Unknown.new("").one_off?).must_equal false
+      it "does not treat formation containers as ephemeral instances" do
+        _(Platform::Heroku.new("web.1").ephemeral_instance?).must_equal false
+        _(Platform::Heroku.new("worker.2").ephemeral_instance?).must_equal false
+        _(Platform::Heroku.new("runner-1").ephemeral_instance?).must_equal false
+        _(Platform::Scalingo.new("web-1").ephemeral_instance?).must_equal false
+        _(Platform::Scalingo.new("worker-2").ephemeral_instance?).must_equal false
+      end
+
+      it "never treats opaque-id platforms as ephemeral instances" do
+        _(Platform::Render.new("5497f74465-m5wwr", service_id: "srv-x").ephemeral_instance?).must_equal false
+        _(Platform::Fly.new("683d924b322418").ephemeral_instance?).must_equal false
+        _(Platform::Unknown.new("").ephemeral_instance?).must_equal false
       end
 
       it "strips the service id prefix from the Render instance id" do

--- a/judoscale-ruby/test/reporter_test.rb
+++ b/judoscale-ruby/test/reporter_test.rb
@@ -132,6 +132,22 @@ module Judoscale
         _(log_string).must_include "Set api_base_url to enable metrics reporting"
       end
 
+      [
+        ["Heroku release", Platform::Heroku.new("release.1")],
+        ["Heroku", Platform::Heroku.new("run.1234")],
+        ["Scalingo", Platform::Scalingo.new("one-off-1234")]
+      ].each do |platform_name, platform|
+        it "does not run the reporter thread in a #{platform_name} ephemeral instance" do
+          Judoscale.configure { |config| config.current_platform = platform }
+
+          Reporter.instance.stub(:run_loop, ->(*) { raise "SHOULD NOT BE CALLED" }) {
+            Reporter.instance.start!(Config.instance, Judoscale.adapters)
+          }
+
+          _(log_string).must_include "Reporter not started: in an ephemeral container"
+        end
+      end
+
       it "does not run the reporter thread when there are no metrics collectors" do
         Reporter.instance.stub(:run_loop, ->(*) { raise "SHOULD NOT BE CALLED" }) {
           Reporter.instance.start!(Config.instance, Judoscale.adapters.select { |a| a.metrics_collector.nil? })


### PR DESCRIPTION
## Summary

- Treat release and one-off runtime containers as ephemeral platform instances.
- Skip reporting from ephemeral containers in the shared reporter so Rails and Rack entry points behave consistently.
- Keep redundant-instance behavior unchanged.

## Design decisions

The reporter owns the skip behavior because ephemeral containers should never report regardless of which framework entry point starts Judoscale. Platform subclasses own the naming rules because only Heroku and Scalingo expose these container conventions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to skipping metrics reporting on ephemeral containers (including new Heroku release phase); redundant-instance logic is untouched.
> 
> **Overview**
> Ephemeral container handling is **centralized in the shared `Reporter`**: `start!` returns early when `config.current_platform.ephemeral_instance?`, so Rails and other entry points no longer duplicate that check (Rails railtie drops `in_one_off_container?`).
> 
> Platform naming is updated from **`one_off?` to `ephemeral_instance?`**. **Heroku** now treats **`release.*`** dynos (in addition to **`run.*`**) as ephemeral, with case-normalized prefix matching. **Scalingo** still treats **`one-off-*`** as ephemeral. Formation dynos/containers are unchanged.
> 
> Tests cover the rename, release dynos, and reporter behavior for Heroku release, Heroku one-off, and Scalingo one-off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8399c7f2974e3bcebd63723bf4ae3942297410c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->